### PR TITLE
feat(blueprint_query, blueprint_modify): recursive get_defaults + nested-subobject writes for instanced UObjects

### DIFF
--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/MCPParamValidator.cpp
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/MCPParamValidator.cpp
@@ -104,14 +104,61 @@ bool FMCPParamValidator::ValidatePropertyPath(const FString& PropertyPath, FStri
 		return false;
 	}
 
-	// Property paths should only contain alphanumeric, underscore, and dot
+	// Property paths may contain alphanumeric, underscore, dot (segment separator),
+	// and balanced [N] array indices. Reject other characters as a defense-in-depth
+	// measure (the actual property lookup is reflection-based, but we keep the input
+	// surface narrow).
+	int32 BracketDepth = 0;
+	bool bSawIndexDigit = false;
 	for (TCHAR c : PropertyPath)
 	{
+		if (c == TEXT('['))
+		{
+			if (BracketDepth != 0)
+			{
+				OutError = TEXT("Property path cannot contain nested brackets");
+				return false;
+			}
+			BracketDepth = 1;
+			bSawIndexDigit = false;
+			continue;
+		}
+		if (c == TEXT(']'))
+		{
+			if (BracketDepth != 1)
+			{
+				OutError = TEXT("Property path has unbalanced ']'");
+				return false;
+			}
+			if (!bSawIndexDigit)
+			{
+				OutError = TEXT("Property path has empty bracket pair '[]'");
+				return false;
+			}
+			BracketDepth = 0;
+			continue;
+		}
+		if (BracketDepth == 1)
+		{
+			if (!FChar::IsDigit(c))
+			{
+				OutError = FString::Printf(TEXT("Property path bracket body must be numeric, got '%c'"), c);
+				return false;
+			}
+			bSawIndexDigit = true;
+			continue;
+		}
 		if (!FChar::IsAlnum(c) && c != TEXT('_') && c != TEXT('.'))
 		{
-			OutError = FString::Printf(TEXT("Property path contains invalid character: '%c'. Only alphanumeric, underscore, and dot are allowed."), c);
+			OutError = FString::Printf(TEXT("Property path contains invalid character: '%c'. Only alphanumeric, underscore, dot, and balanced [N] indices are allowed."), c);
 			return false;
 		}
+	}
+
+	if (BracketDepth != 0)
+	{
+		OutError = TEXT("Property path has unclosed '['");
+		return false;
 	}
 
 	// Check for double dots which could indicate path traversal attempts

--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/MCPParamValidator.cpp
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/MCPParamValidator.cpp
@@ -108,8 +108,12 @@ bool FMCPParamValidator::ValidatePropertyPath(const FString& PropertyPath, FStri
 	// and balanced [N] array indices. Reject other characters as a defense-in-depth
 	// measure (the actual property lookup is reflection-based, but we keep the input
 	// surface narrow).
+	// Cap bracket-body length to defang integer-overflow attacks. 9 digits permit any value
+	// up to 999_999_999 — far above realistic UE array sizes — and stay well clear of
+	// MAX_int32 (2_147_483_647) so the eventual Atoi/Atoi64 in the parser can't wrap.
+	const int32 MaxBracketDigits = 9;
 	int32 BracketDepth = 0;
-	bool bSawIndexDigit = false;
+	int32 IndexDigitsSeen = 0;
 	for (TCHAR c : PropertyPath)
 	{
 		if (c == TEXT('['))
@@ -120,7 +124,7 @@ bool FMCPParamValidator::ValidatePropertyPath(const FString& PropertyPath, FStri
 				return false;
 			}
 			BracketDepth = 1;
-			bSawIndexDigit = false;
+			IndexDigitsSeen = 0;
 			continue;
 		}
 		if (c == TEXT(']'))
@@ -130,7 +134,7 @@ bool FMCPParamValidator::ValidatePropertyPath(const FString& PropertyPath, FStri
 				OutError = TEXT("Property path has unbalanced ']'");
 				return false;
 			}
-			if (!bSawIndexDigit)
+			if (IndexDigitsSeen == 0)
 			{
 				OutError = TEXT("Property path has empty bracket pair '[]'");
 				return false;
@@ -145,7 +149,12 @@ bool FMCPParamValidator::ValidatePropertyPath(const FString& PropertyPath, FStri
 				OutError = FString::Printf(TEXT("Property path bracket body must be numeric, got '%c'"), c);
 				return false;
 			}
-			bSawIndexDigit = true;
+			IndexDigitsSeen++;
+			if (IndexDigitsSeen > MaxBracketDigits)
+			{
+				OutError = FString::Printf(TEXT("Property path array index exceeds %d digits"), MaxBracketDigits);
+				return false;
+			}
 			continue;
 		}
 		if (!FChar::IsAlnum(c) && c != TEXT('_') && c != TEXT('.'))

--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/Tools/MCPTool_BlueprintModify.cpp
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/Tools/MCPTool_BlueprintModify.cpp
@@ -6,6 +6,7 @@
 #include "GraphLayoutHelper.h"
 #include "DebugPrintBuilder.h"
 #include "BlueprintLoader.h"
+#include "PropertyPathParser.h"
 #include "MCP/MCPParamValidator.h"
 #include "MCP/MCPBlueprintLoadContext.h"
 #include "UnrealClaudeModule.h"
@@ -1061,6 +1062,51 @@ FMCPToolResult FMCPTool_BlueprintModify::ExecuteSetPinValue(const TSharedRef<FJs
 
 // ===== Level 5: Component Default Operations =====
 
+UObject* FMCPTool_BlueprintModify::ResolveComponentTemplate(UBlueprint* Blueprint, const FString& ComponentName, FString& OutError) const
+{
+	if (!Blueprint)
+	{
+		OutError = TEXT("Blueprint is null");
+		return nullptr;
+	}
+
+	// Strategy 1: Search SCS nodes (Blueprint-origin components like AIPerception on a controller).
+	if (Blueprint->SimpleConstructionScript)
+	{
+		const TArray<USCS_Node*>& AllNodes = Blueprint->SimpleConstructionScript->GetAllNodes();
+		for (USCS_Node* Node : AllNodes)
+		{
+			if (Node && Node->ComponentTemplate && Node->GetVariableName().ToString() == ComponentName)
+			{
+				return Node->ComponentTemplate;
+			}
+		}
+	}
+
+	// Strategy 2: Fall back to CDO components (C++-origin like capsule, mesh, movement).
+	if (Blueprint->GeneratedClass)
+	{
+		AActor* CDO = Cast<AActor>(Blueprint->GeneratedClass->GetDefaultObject());
+		if (CDO)
+		{
+			TArray<UActorComponent*> Components;
+			CDO->GetComponents(Components);
+			for (UActorComponent* Comp : Components)
+			{
+				if (Comp && Comp->GetName() == ComponentName)
+				{
+					return Comp;
+				}
+			}
+		}
+	}
+
+	OutError = FString::Printf(
+		TEXT("Component '%s' not found in Blueprint '%s'. Use blueprint_query get_components to see available components."),
+		*ComponentName, *Blueprint->GetPathName());
+	return nullptr;
+}
+
 FMCPToolResult FMCPTool_BlueprintModify::ExecuteSetComponentDefault(const TSharedRef<FJsonObject>& Params)
 {
 	// Extract parameters
@@ -1090,47 +1136,12 @@ FMCPToolResult FMCPTool_BlueprintModify::ExecuteSetComponentDefault(const TShare
 		return LoadError.GetValue();
 	}
 
-	// Find the component template
-	UObject* ComponentTemplate = nullptr;
-
-	// Strategy 1: Search SCS nodes (Blueprint-origin components)
-	if (Context.Blueprint->SimpleConstructionScript)
-	{
-		const TArray<USCS_Node*>& AllNodes = Context.Blueprint->SimpleConstructionScript->GetAllNodes();
-		for (USCS_Node* Node : AllNodes)
-		{
-			if (Node && Node->ComponentTemplate && Node->GetVariableName().ToString() == ComponentName)
-			{
-				ComponentTemplate = Node->ComponentTemplate;
-				break;
-			}
-		}
-	}
-
-	// Strategy 2: Fall back to CDO components (C++-origin components like capsule, mesh, movement)
-	if (!ComponentTemplate && Context.Blueprint->GeneratedClass)
-	{
-		AActor* CDO = Cast<AActor>(Context.Blueprint->GeneratedClass->GetDefaultObject());
-		if (CDO)
-		{
-			TArray<UActorComponent*> Components;
-			CDO->GetComponents(Components);
-			for (UActorComponent* Comp : Components)
-			{
-				if (Comp && Comp->GetName() == ComponentName)
-				{
-					ComponentTemplate = Comp;
-					break;
-				}
-			}
-		}
-	}
-
+	// Resolve the component template (SCS first, CDO components fallback)
+	FString ResolveError;
+	UObject* ComponentTemplate = ResolveComponentTemplate(Context.Blueprint, ComponentName, ResolveError);
 	if (!ComponentTemplate)
 	{
-		return FMCPToolResult::Error(FString::Printf(
-			TEXT("Component '%s' not found in Blueprint '%s'. Use blueprint_query get_components to see available components."),
-			*ComponentName, *Context.BlueprintPath));
+		return FMCPToolResult::Error(ResolveError);
 	}
 
 	// Register with undo system
@@ -1404,10 +1415,31 @@ FMCPToolResult FMCPTool_BlueprintModify::ExecuteSetCDODefault(const TSharedRef<F
 		return FMCPToolResult::Error(TEXT("Failed to get Class Default Object"));
 	}
 
-	CDO->Modify();
+	// Optional: re-root the write at an SCS / CDO component template instead of the CDO itself.
+	// Mirrors the read-side 'get_defaults' component_name behavior. Required for nested instanced
+	// subobjects whose CDO field is null because the SCS owns the editor-time template
+	// (e.g. AIPerception on an AIController-derived BP).
+	FString ComponentName;
+	Params->TryGetStringField(TEXT("component_name"), ComponentName);
+
+	UObject* RootObject = CDO;
+	bool bRootedAtComponent = false;
+	if (!ComponentName.IsEmpty())
+	{
+		FString ResolveError;
+		UObject* ComponentTemplate = ResolveComponentTemplate(Context.Blueprint, ComponentName, ResolveError);
+		if (!ComponentTemplate)
+		{
+			return FMCPToolResult::Error(ResolveError);
+		}
+		RootObject = ComponentTemplate;
+		bRootedAtComponent = true;
+	}
+
+	RootObject->Modify();
 
 	FString SetError;
-	if (!SetComponentPropertyFromJson(CDO, PropertyPath, Value, SetError))
+	if (!SetComponentPropertyFromJson(RootObject, PropertyPath, Value, SetError))
 	{
 		return FMCPToolResult::Error(SetError);
 	}
@@ -1419,9 +1451,17 @@ FMCPToolResult FMCPTool_BlueprintModify::ExecuteSetCDODefault(const TSharedRef<F
 
 	TSharedPtr<FJsonObject> ResultData = Context.BuildResultJson();
 	ResultData->SetStringField(TEXT("property"), PropertyPath);
+	if (bRootedAtComponent)
+	{
+		ResultData->SetStringField(TEXT("root"), ComponentName);
+		ResultData->SetStringField(TEXT("root_class"), RootObject->GetClass()->GetName());
+	}
 
 	return FMCPToolResult::Success(
-		FString::Printf(TEXT("Set CDO property '%s' on Blueprint '%s'"), *PropertyPath, *Context.BlueprintPath),
+		FString::Printf(TEXT("Set CDO property '%s' on Blueprint '%s'%s"),
+			*PropertyPath,
+			*Context.BlueprintPath,
+			bRootedAtComponent ? *FString::Printf(TEXT(" (component: %s)"), *ComponentName) : TEXT("")),
 		ResultData
 	);
 }
@@ -1449,17 +1489,14 @@ bool FMCPTool_BlueprintModify::SetComponentPropertyFromJson(UObject* Template, c
 		return false;
 	}
 
-	// Parse dot-separated property path, resolving aliases on each segment
-	TArray<FString> PathParts;
-	PropertyPath.ParseIntoArray(PathParts, TEXT("."), true);
-	for (FString& Part : PathParts)
+	// Tokenize the path via the shared parser. Each returned segment may carry a "[N]" suffix.
+	// Aliases are resolved per-segment on the parsed Name only (never on the raw "Foo[0]" text),
+	// preserving the existing per-segment alias contract.
+	TArray<FString> Segments;
+	FString SplitErr;
+	if (!FPropertyPathParser::SplitPath(PropertyPath, Segments, SplitErr))
 	{
-		Part = ResolvePropertyAlias(Part);
-	}
-
-	if (PathParts.Num() == 0)
-	{
-		OutError = TEXT("Empty property path");
+		OutError = SplitErr;
 		return false;
 	}
 
@@ -1467,15 +1504,73 @@ bool FMCPTool_BlueprintModify::SetComponentPropertyFromJson(UObject* Template, c
 	UStruct* CurrentStruct = Template->GetClass();
 	void* CurrentContainer = Template;
 
-	for (int32 i = 0; i < PathParts.Num() - 1; ++i)
+	for (int32 i = 0; i < Segments.Num() - 1; ++i)
 	{
-		FProperty* Prop = CurrentStruct->FindPropertyByName(FName(*PathParts[i]));
+		FString SegName;
+		int32 SegIndex = INDEX_NONE;
+		FString ParseErr;
+		if (!FPropertyPathParser::ParseSegment(Segments[i], SegName, SegIndex, ParseErr))
+		{
+			OutError = ParseErr;
+			return false;
+		}
+		SegName = ResolvePropertyAlias(SegName);
+
+		FProperty* Prop = CurrentStruct->FindPropertyByName(FName(*SegName));
 		if (!Prop)
 		{
-			OutError = FString::Printf(TEXT("Property '%s' not found on %s"), *PathParts[i], *CurrentStruct->GetName());
+			OutError = FString::Printf(TEXT("Property '%s' not found on %s"), *SegName, *CurrentStruct->GetName());
 			return false;
 		}
 
+		// Indexed segment — must be an array; advance into the indexed element.
+		if (SegIndex != INDEX_NONE)
+		{
+			FArrayProperty* ArrayProp = CastField<FArrayProperty>(Prop);
+			if (!ArrayProp)
+			{
+				OutError = FString::Printf(TEXT("Property '%s' has index [%d] but is not an array (type: %s)"),
+					*SegName, SegIndex, *Prop->GetCPPType());
+				return false;
+			}
+
+			void* ArrayValuePtr = ArrayProp->ContainerPtrToValuePtr<void>(CurrentContainer);
+			FScriptArrayHelper ArrayHelper(ArrayProp, ArrayValuePtr);
+			if (SegIndex >= ArrayHelper.Num())
+			{
+				OutError = FString::Printf(TEXT("Index [%d] out of bounds for '%s' (size: %d)"),
+					SegIndex, *SegName, ArrayHelper.Num());
+				return false;
+			}
+
+			void* ElemPtr = ArrayHelper.GetRawPtr(SegIndex);
+			FProperty* InnerProp = ArrayProp->Inner;
+
+			if (FStructProperty* StructInner = CastField<FStructProperty>(InnerProp))
+			{
+				CurrentContainer = ElemPtr;
+				CurrentStruct = StructInner->Struct;
+				continue;
+			}
+			if (FObjectProperty* ObjInner = CastField<FObjectProperty>(InnerProp))
+			{
+				UObject* NestedObj = ObjInner->GetObjectPropertyValue(ElemPtr);
+				if (!NestedObj)
+				{
+					OutError = FString::Printf(TEXT("Element '%s[%d]' is null"), *SegName, SegIndex);
+					return false;
+				}
+				CurrentContainer = NestedObj;
+				CurrentStruct = NestedObj->GetClass();
+				continue;
+			}
+
+			OutError = FString::Printf(TEXT("Cannot navigate into '%s[%d]' (inner type: %s)"),
+				*SegName, SegIndex, *InnerProp->GetCPPType());
+			return false;
+		}
+
+		// No index — existing struct/object navigation.
 		FStructProperty* StructProp = CastField<FStructProperty>(Prop);
 		if (StructProp)
 		{
@@ -1490,7 +1585,7 @@ bool FMCPTool_BlueprintModify::SetComponentPropertyFromJson(UObject* Template, c
 			UObject* NestedObj = ObjProp->GetObjectPropertyValue(ObjProp->ContainerPtrToValuePtr<void>(CurrentContainer));
 			if (!NestedObj)
 			{
-				OutError = FString::Printf(TEXT("Nested object '%s' is null"), *PathParts[i]);
+				OutError = FString::Printf(TEXT("Nested object '%s' is null"), *SegName);
 				return false;
 			}
 			CurrentContainer = NestedObj;
@@ -1498,20 +1593,60 @@ bool FMCPTool_BlueprintModify::SetComponentPropertyFromJson(UObject* Template, c
 			continue;
 		}
 
-		OutError = FString::Printf(TEXT("Cannot navigate through '%s' (type: %s) — not a struct or object property"), *PathParts[i], *Prop->GetCPPType());
+		OutError = FString::Printf(TEXT("Cannot navigate through '%s' (type: %s) — not a struct or object property"), *SegName, *Prop->GetCPPType());
 		return false;
 	}
 
-	// Find the leaf property
-	const FString& LeafName = PathParts.Last();
-	FProperty* LeafProp = CurrentStruct->FindPropertyByName(FName(*LeafName));
-	if (!LeafProp)
+	// Leaf segment.
+	FString LeafName;
+	int32 LeafIndex = INDEX_NONE;
+	FString LeafErr;
+	if (!FPropertyPathParser::ParseSegment(Segments.Last(), LeafName, LeafIndex, LeafErr))
+	{
+		OutError = LeafErr;
+		return false;
+	}
+	LeafName = ResolvePropertyAlias(LeafName);
+
+	FProperty* ResolvedLeaf = CurrentStruct->FindPropertyByName(FName(*LeafName));
+	if (!ResolvedLeaf)
 	{
 		OutError = FString::Printf(TEXT("Property '%s' not found on %s"), *LeafName, *CurrentStruct->GetName());
 		return false;
 	}
 
-	void* ValuePtr = LeafProp->ContainerPtrToValuePtr<void>(CurrentContainer);
+	// LeafProp / ValuePtr feed the type-dispatch ladder below. With an index, the dispatch
+	// targets the array's inner property at the indexed element pointer; without an index,
+	// it targets the property itself at its container offset (legacy behavior).
+	FProperty* LeafProp = ResolvedLeaf;
+	void* ValuePtr = nullptr;
+
+	if (LeafIndex != INDEX_NONE)
+	{
+		FArrayProperty* ArrayProp = CastField<FArrayProperty>(ResolvedLeaf);
+		if (!ArrayProp)
+		{
+			OutError = FString::Printf(TEXT("Leaf '%s' has index [%d] but is not an array (type: %s)"),
+				*LeafName, LeafIndex, *ResolvedLeaf->GetCPPType());
+			return false;
+		}
+
+		void* ArrayValuePtr = ArrayProp->ContainerPtrToValuePtr<void>(CurrentContainer);
+		FScriptArrayHelper ArrayHelper(ArrayProp, ArrayValuePtr);
+		if (LeafIndex >= ArrayHelper.Num())
+		{
+			OutError = FString::Printf(TEXT("Leaf index [%d] out of bounds for '%s' (size: %d)"),
+				LeafIndex, *LeafName, ArrayHelper.Num());
+			return false;
+		}
+
+		LeafProp = ArrayProp->Inner;
+		ValuePtr = ArrayHelper.GetRawPtr(LeafIndex);
+	}
+	else
+	{
+		ValuePtr = ResolvedLeaf->ContainerPtrToValuePtr<void>(CurrentContainer);
+	}
 
 	// Type dispatch
 	if (FNumericProperty* NumProp = CastField<FNumericProperty>(LeafProp))

--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/Tools/MCPTool_BlueprintModify.cpp
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/Tools/MCPTool_BlueprintModify.cpp
@@ -1122,6 +1122,10 @@ FMCPToolResult FMCPTool_BlueprintModify::ExecuteSetComponentDefault(const TShare
 	{
 		return Error.GetValue();
 	}
+	if (!ValidatePropertyPathParam(PropertyPath, Error))
+	{
+		return Error.GetValue();
+	}
 
 	if (!Params->HasField(TEXT("value")))
 	{
@@ -1388,6 +1392,10 @@ FMCPToolResult FMCPTool_BlueprintModify::ExecuteSetCDODefault(const TSharedRef<F
 	TOptional<FMCPToolResult> Error;
 	FString PropertyPath;
 	if (!ExtractRequiredString(Params, TEXT("property"), PropertyPath, Error))
+	{
+		return Error.GetValue();
+	}
+	if (!ValidatePropertyPathParam(PropertyPath, Error))
 	{
 		return Error.GetValue();
 	}

--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/Tools/MCPTool_BlueprintModify.h
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/Tools/MCPTool_BlueprintModify.h
@@ -56,7 +56,7 @@ public:
 			"Level 2 (Structure): 'create', 'reparent', 'add_variable', 'remove_variable', 'add_function', 'remove_function'\n"
 			"Level 3 (Nodes): 'add_node', 'add_nodes' (batch), 'delete_node'\n"
 			"Level 4 (Wiring): 'connect_pins', 'disconnect_pins', 'set_pin_value'\n"
-			"Level 5 (Defaults): 'set_component_default' - set default property on BP component, 'set_cdo_default' - set top-level CDO property, 'add_component' - add component to BP, 'remove_component' - remove BP-added (SCS) component\n"
+			"Level 5 (Defaults): 'set_cdo_default' - set CDO property (optional 'component_name' re-roots at an SCS/CDO component; supports '[N]' array indices in 'property'), 'set_component_default' - same as set_cdo_default+component_name (legacy), 'add_component' - add component to BP, 'remove_component' - remove BP-added (SCS) component\n"
 			"Level 6 (Debug): 'add_debug_print' - add labeled debug print subgraph, 'remove_debug_print' - remove by label\n"
 			"Level 7 (Layout): 'layout_graph' - auto-arrange nodes into readable BFS grid layout\n"
 			"Validation: 'compile' - compile single BP with diagnostics, 'compile_all' - batch compile under path\n\n"
@@ -70,6 +70,7 @@ public:
 			"  Add node: {\"operation\":\"add_node\",\"blueprint_path\":\"/Game/BP/MyBP\",\"node_type\":\"CallFunction\",\"node_params\":{\"function\":\"PrintString\"}}\n"
 			"  Wire pins: {\"operation\":\"connect_pins\",\"blueprint_path\":\"/Game/BP/MyBP\",\"source_node_id\":\"<id>\",\"target_node_id\":\"<id>\"}\n"
 			"  Set CDO default: {\"operation\":\"set_cdo_default\",\"blueprint_path\":\"/Game/BP/MyBP\",\"property\":\"MaxWalkSpeed\",\"value\":600}\n"
+			"  Set component template default: {\"operation\":\"set_cdo_default\",\"blueprint_path\":\"/Game/AI/BP_AIController\",\"component_name\":\"AIPerception\",\"property\":\"SensesConfig[0].SightRadius\",\"value\":2500}\n"
 			"  Layout graph: {\"operation\":\"layout_graph\",\"blueprint_path\":\"/Game/BP/MyBP\"}"
 		);
 		Info.Parameters = {
@@ -145,13 +146,13 @@ public:
 			FMCPToolParameter(TEXT("attach_to"), TEXT("string"),
 				TEXT("For 'add_component': parent component variable name to attach to"), false),
 
-			// For set_component_default / add_component / remove_component
+			// For set_cdo_default / set_component_default / add_component / remove_component
 			FMCPToolParameter(TEXT("component_name"), TEXT("string"),
-				TEXT("Component variable name (e.g., 'CameraBoom', 'CharacterMovement0', 'Mesh')"), false),
+				TEXT("Component variable name (e.g., 'CameraBoom', 'CharacterMovement0', 'Mesh', 'AIPerception'). For 'set_cdo_default' it re-roots the write at this component's SCS/CDO template instead of the Blueprint CDO."), false),
 			FMCPToolParameter(TEXT("socket_name"), TEXT("string"),
 				TEXT("add_component: bone/socket name to attach to (e.g., 'hand_r')"), false),
 			FMCPToolParameter(TEXT("property"), TEXT("string"),
-				TEXT("Property path with dot notation (e.g., 'RelativeRotation', 'RelativeRotation.Yaw', 'MaxWalkSpeed')"), false),
+				TEXT("Property path. Dot navigates structs/objects; '[N]' indexes arrays. Examples: 'RelativeRotation', 'RelativeRotation.Yaw', 'MaxWalkSpeed', 'SensesConfig[0].SightRadius'."), false),
 			FMCPToolParameter(TEXT("value"), TEXT("any"),
 				TEXT("Value to set: number, bool, string, or object (e.g., {\"pitch\":0,\"yaw\":-90,\"roll\":0})"), false),
 
@@ -227,10 +228,16 @@ private:
 	FMCPToolResult ExecuteCompile(const TSharedRef<FJsonObject>& Params);
 	FMCPToolResult ExecuteCompileAll(const TSharedRef<FJsonObject>& Params);
 
-	// Property reflection helpers for set_component_default
+	// Property reflection helpers for set_component_default / set_cdo_default
 	bool SetComponentPropertyFromJson(UObject* Template, const FString& PropertyPath, const TSharedPtr<FJsonValue>& Value, FString& OutError);
 	bool SetNumericValue(FNumericProperty* NumProp, void* ValuePtr, const TSharedPtr<FJsonValue>& Value);
 	bool SetStructValue(FStructProperty* StructProp, void* ValuePtr, const TSharedPtr<FJsonValue>& Value);
+
+	// Resolve a component template by variable name on a Blueprint.
+	// Searches SCS templates first (Blueprint-added components like AIPerception),
+	// falls back to CDO actor-components (C++-declared components present on the actor CDO).
+	// Returns nullptr with a populated OutError on miss.
+	UObject* ResolveComponentTemplate(UBlueprint* Blueprint, const FString& ComponentName, FString& OutError) const;
 
 	// Helpers
 	EBlueprintType ParseBlueprintType(const FString& TypeString);

--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/Tools/MCPTool_BlueprintQuery.cpp
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/Tools/MCPTool_BlueprintQuery.cpp
@@ -9,6 +9,9 @@
 #include "UnrealClaudeModule.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "Engine/Blueprint.h"
+#include "Engine/SimpleConstructionScript.h"
+#include "Engine/SCS_Node.h"
+#include "Components/ActorComponent.h"
 
 FMCPToolResult FMCPTool_BlueprintQuery::Execute(const TSharedRef<FJsonObject>& Params)
 {
@@ -601,6 +604,72 @@ FMCPToolResult FMCPTool_BlueprintQuery::ExecuteGetDefaults(const TSharedRef<FJso
 	}
 	ResponseData->SetStringField(TEXT("parent_class"), ParentClassName);
 
+	// --- Optional: root the read at a component instead of the CDO ---
+	FString ComponentName;
+	Params->TryGetStringField(TEXT("component_name"), ComponentName);
+
+	UObject* RootObject = CDO;
+	bool bRootedAtComponent = false;
+	if (!ComponentName.IsEmpty())
+	{
+		// Try CDO components first (covers C++-declared components present on the CDO).
+		UObject* ResolvedComponent = nullptr;
+		if (AActor* ActorCDO = Cast<AActor>(CDO))
+		{
+			TInlineComponentArray<UActorComponent*> AllComponents;
+			ActorCDO->GetComponents(AllComponents);
+			const FName SearchName(*ComponentName);
+			for (UActorComponent* Comp : AllComponents)
+			{
+				if (Comp && Comp->GetFName() == SearchName)
+				{
+					ResolvedComponent = Comp;
+					break;
+				}
+			}
+		}
+
+		// Fall back to SCS templates (covers Blueprint-added components like AIPerception on a controller,
+		// whose CDO field is null because the SCS owns the editor-time template).
+		if (!ResolvedComponent && Blueprint->SimpleConstructionScript)
+		{
+			const FName SearchName(*ComponentName);
+			for (USCS_Node* Node : Blueprint->SimpleConstructionScript->GetAllNodes())
+			{
+				if (Node && Node->GetVariableName() == SearchName && Node->ComponentTemplate)
+				{
+					ResolvedComponent = Node->ComponentTemplate;
+					break;
+				}
+			}
+		}
+
+		if (!ResolvedComponent)
+		{
+			return FMCPToolResult::Error(FString::Printf(
+				TEXT("Component '%s' not found on Blueprint '%s' (checked CDO components and SCS templates)"),
+				*ComponentName, *Blueprint->GetName()));
+		}
+
+		RootObject = ResolvedComponent;
+		bRootedAtComponent = true;
+		ResponseData->SetStringField(TEXT("root"), ComponentName);
+		ResponseData->SetStringField(TEXT("root_class"), ResolvedComponent->GetClass()->GetName());
+	}
+
+	// --- Build recursion context (default-constructed = current behavior, no recursion) ---
+	double MaxDepthD = 0.0;
+	Params->TryGetNumberField(TEXT("max_depth"), MaxDepthD);
+	double MaxPropsD = 500.0;
+	Params->TryGetNumberField(TEXT("max_properties"), MaxPropsD);
+	bool bIncludeNonEdit = false;
+	Params->TryGetBoolField(TEXT("include_non_edit"), bIncludeNonEdit);
+
+	FPropertyRecursionContext Ctx;
+	Ctx.MaxDepth = FMath::Clamp(static_cast<int32>(MaxDepthD), 0, 8);
+	Ctx.MaxProperties = FMath::Clamp(static_cast<int32>(MaxPropsD), 1, 5000);
+	Ctx.bIncludeNonEdit = bIncludeNonEdit;
+
 	const TArray<TSharedPtr<FJsonValue>>* PropertiesArray = nullptr;
 	if (Params->TryGetArrayField(TEXT("properties"), PropertiesArray) && PropertiesArray && PropertiesArray->Num() > 0)
 	{
@@ -616,7 +685,7 @@ FMCPToolResult FMCPTool_BlueprintQuery::ExecuteGetDefaults(const TSharedRef<FJso
 				continue;
 			}
 
-			FPropertySerializer::FPropertyPathResult Result = FPropertySerializer::GetPropertyByPath(CDO, PropName);
+			FPropertySerializer::FPropertyPathResult Result = FPropertySerializer::GetPropertyByPath(RootObject, PropName, Ctx);
 			if (Result.bSuccess)
 			{
 				Values->SetField(PropName, Result.Value);
@@ -637,25 +706,33 @@ FMCPToolResult FMCPTool_BlueprintQuery::ExecuteGetDefaults(const TSharedRef<FJso
 		}
 
 		return FMCPToolResult::Success(
-			FString::Printf(TEXT("Read %d CDO properties from '%s'"), SuccessCount, *Blueprint->GetName()),
+			FString::Printf(TEXT("Read %d properties from '%s'%s"),
+				SuccessCount,
+				*Blueprint->GetName(),
+				bRootedAtComponent ? *FString::Printf(TEXT(" (component: %s)"), *ComponentName) : TEXT("")),
 			ResponseData
 		);
 	}
 	else
 	{
+		// Full-dump path. ParentCDO comparison is only meaningful when reading the actual Blueprint CDO;
+		// for component templates, pass nullptr so all configured values surface.
 		UObject* ParentCDO = nullptr;
-		if (Blueprint->ParentClass)
+		if (!bRootedAtComponent && Blueprint->ParentClass)
 		{
 			ParentCDO = Blueprint->ParentClass->GetDefaultObject();
 		}
 
-		TSharedPtr<FJsonObject> Overrides = FPropertySerializer::GetCDOOverrides(CDO, ParentCDO, true);
+		TSharedPtr<FJsonObject> Overrides = FPropertySerializer::GetCDOOverrides(RootObject, ParentCDO, true, Ctx);
 
 		ResponseData->SetObjectField(TEXT("overrides"), Overrides);
 		ResponseData->SetNumberField(TEXT("count"), Overrides->Values.Num());
 
 		return FMCPToolResult::Success(
-			FString::Printf(TEXT("Found %d CDO overrides on '%s'"), Overrides->Values.Num(), *Blueprint->GetName()),
+			FString::Printf(TEXT("Found %d overrides on '%s'%s"),
+				Overrides->Values.Num(),
+				*Blueprint->GetName(),
+				bRootedAtComponent ? *FString::Printf(TEXT(" (component: %s)"), *ComponentName) : TEXT("")),
 			ResponseData
 		);
 	}

--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/Tools/MCPTool_BlueprintQuery.cpp
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/Tools/MCPTool_BlueprintQuery.cpp
@@ -612,26 +612,13 @@ FMCPToolResult FMCPTool_BlueprintQuery::ExecuteGetDefaults(const TSharedRef<FJso
 	bool bRootedAtComponent = false;
 	if (!ComponentName.IsEmpty())
 	{
-		// Try CDO components first (covers C++-declared components present on the CDO).
+		// Resolution order MUST match the write side (FMCPTool_BlueprintModify::ResolveComponentTemplate):
+		// SCS templates first (covers Blueprint-added components like AIPerception on a controller,
+		// whose CDO field is null because the SCS owns the editor-time template), then CDO components
+		// (covers C++-declared components present on the actor CDO). Mismatched ordering would make
+		// `get_defaults` and `set_cdo_default` address different objects when names collide.
 		UObject* ResolvedComponent = nullptr;
-		if (AActor* ActorCDO = Cast<AActor>(CDO))
-		{
-			TInlineComponentArray<UActorComponent*> AllComponents;
-			ActorCDO->GetComponents(AllComponents);
-			const FName SearchName(*ComponentName);
-			for (UActorComponent* Comp : AllComponents)
-			{
-				if (Comp && Comp->GetFName() == SearchName)
-				{
-					ResolvedComponent = Comp;
-					break;
-				}
-			}
-		}
-
-		// Fall back to SCS templates (covers Blueprint-added components like AIPerception on a controller,
-		// whose CDO field is null because the SCS owns the editor-time template).
-		if (!ResolvedComponent && Blueprint->SimpleConstructionScript)
+		if (Blueprint->SimpleConstructionScript)
 		{
 			const FName SearchName(*ComponentName);
 			for (USCS_Node* Node : Blueprint->SimpleConstructionScript->GetAllNodes())
@@ -646,8 +633,26 @@ FMCPToolResult FMCPTool_BlueprintQuery::ExecuteGetDefaults(const TSharedRef<FJso
 
 		if (!ResolvedComponent)
 		{
+			if (AActor* ActorCDO = Cast<AActor>(CDO))
+			{
+				TInlineComponentArray<UActorComponent*> AllComponents;
+				ActorCDO->GetComponents(AllComponents);
+				const FName SearchName(*ComponentName);
+				for (UActorComponent* Comp : AllComponents)
+				{
+					if (Comp && Comp->GetFName() == SearchName)
+					{
+						ResolvedComponent = Comp;
+						break;
+					}
+				}
+			}
+		}
+
+		if (!ResolvedComponent)
+		{
 			return FMCPToolResult::Error(FString::Printf(
-				TEXT("Component '%s' not found on Blueprint '%s' (checked CDO components and SCS templates)"),
+				TEXT("Component '%s' not found on Blueprint '%s' (checked SCS templates and CDO components)"),
 				*ComponentName, *Blueprint->GetName()));
 		}
 

--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/Tools/MCPTool_BlueprintQuery.h
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/Tools/MCPTool_BlueprintQuery.h
@@ -43,7 +43,7 @@ public:
 			"- 'get_event_graph': Get event graph execution chains (events, function calls, branches)\n"
 			"- 'get_anim_graph': Get anim graph pose chain (Root backward through blends/slots/players)\n"
 			"- 'get_state_machine_detail': Get state machine states, transitions, and rule expressions\n"
-			"- 'get_defaults': Get CDO default property values (all overrides or specific properties)\n"
+			"- 'get_defaults': Get CDO default property values. With 'max_depth' > 0 recurses into instanced UObject subobjects; with 'component_name' reads from an SCS component template instead of the CDO. Property paths support [N] array indexing (e.g. SensesConfig[0].SightRadius).\n"
 			"- 'find_nodes': Search nodes by class/label/type — lightweight summaries, no pin arrays\n"
 			"- 'get_node': Single node by ID with complete pin data\n"
 			"- 'verify_connection': Check if connection exists between two nodes/pins\n"
@@ -78,7 +78,7 @@ public:
 			FMCPToolParameter(TEXT("include_graphs"), TEXT("boolean"),
 				TEXT("Include graph info in inspect result"), false, TEXT("false")),
 			FMCPToolParameter(TEXT("component_name"), TEXT("string"),
-				TEXT("For 'get_components': return only this component (by CDO name or SCS variable name)"), false),
+				TEXT("For 'get_components': return only this component (by CDO name or SCS variable name). For 'get_defaults': read properties from this component's SCS template / CDO component instead of the Blueprint CDO root."), false),
 			FMCPToolParameter(TEXT("actor_label"), TEXT("string"),
 				TEXT("For 'get_collision': inspect a level actor instead of Blueprint CDO"), false),
 			FMCPToolParameter(TEXT("graph_name"), TEXT("string"),
@@ -86,7 +86,7 @@ public:
 			FMCPToolParameter(TEXT("state_machine_name"), TEXT("string"),
 				TEXT("For 'get_state_machine_detail': which state machine to inspect"), false),
 			FMCPToolParameter(TEXT("properties"), TEXT("array"),
-				TEXT("For 'get_defaults': specific property names/paths to read (omit for all overrides)"), false),
+				TEXT("For 'get_defaults': specific property names/paths to read (omit for all overrides). Supports '.' for struct/object navigation and '[N]' array indices, e.g. 'SensesConfig[0].SightRadius'."), false),
 			FMCPToolParameter(TEXT("search"), TEXT("string"),
 				TEXT("For 'find_nodes': label substring to search for"), false),
 			FMCPToolParameter(TEXT("node_class"), TEXT("string"),
@@ -108,7 +108,11 @@ public:
 			FMCPToolParameter(TEXT("pin_filter"), TEXT("string"),
 				TEXT("For 'get_node_connections': comma-separated pin names to include"), false),
 			FMCPToolParameter(TEXT("max_depth"), TEXT("number"),
-				TEXT("For 'get_exec_chain': max walk depth (default: 50)"), false, TEXT("50"))
+				TEXT("For 'get_exec_chain' (default: 50): max walk depth. For 'get_defaults' (default: 0, max: 8): recurse into instanced UObject subobject fields."), false, TEXT("50")),
+			FMCPToolParameter(TEXT("max_properties"), TEXT("number"),
+				TEXT("For 'get_defaults' with recursion: total property-count cap (default: 500, max: 5000)."), false, TEXT("500")),
+			FMCPToolParameter(TEXT("include_non_edit"), TEXT("boolean"),
+				TEXT("For 'get_defaults': include non-editable / non-BP-visible properties (default: false). Transient/deprecated/delegate properties are still skipped."), false, TEXT("false"))
 		};
 		Info.Annotations = FMCPToolAnnotations::ReadOnly();
 		return Info;

--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/Tools/MCPTool_SetProperty.cpp
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/Tools/MCPTool_SetProperty.cpp
@@ -2,10 +2,12 @@
 
 #include "MCPTool_SetProperty.h"
 #include "MCP/MCPParamValidator.h"
+#include "PropertyPathParser.h"
 #include "UnrealClaudeModule.h"
 #include "Editor.h"
 #include "Engine/World.h"
 #include "GameFramework/Actor.h"
+#include "Components/ActorComponent.h"
 #include "EngineUtils.h"
 #include "UObject/PropertyAccessUtil.h"
 
@@ -51,9 +53,36 @@ FMCPToolResult FMCPTool_SetProperty::Execute(const TSharedRef<FJsonObject>& Para
 		return ActorNotFoundError(ActorName);
 	}
 
+	// Optional: re-root the write at a specific component (exact-match by name) instead of the
+	// actor itself. This eliminates the in-path component lookup and mirrors blueprint_modify's
+	// 'set_cdo_default + component_name' shape.
+	FString ComponentName;
+	Params->TryGetStringField(TEXT("component_name"), ComponentName);
+
+	UObject* TargetRoot = Actor;
+	if (!ComponentName.IsEmpty())
+	{
+		UActorComponent* FoundComponent = nullptr;
+		const FName SearchName(*ComponentName);
+		for (UActorComponent* Comp : Actor->GetComponents())
+		{
+			if (Comp && Comp->GetFName() == SearchName)
+			{
+				FoundComponent = Comp;
+				break;
+			}
+		}
+		if (!FoundComponent)
+		{
+			return FMCPToolResult::Error(FString::Printf(
+				TEXT("Component '%s' not found on actor '%s'"), *ComponentName, *Actor->GetName()));
+		}
+		TargetRoot = FoundComponent;
+	}
+
 	// Set the property
 	FString ErrorMessage;
-	if (!SetPropertyFromJson(Actor, PropertyPath, Value, ErrorMessage))
+	if (!SetPropertyFromJson(TargetRoot, PropertyPath, Value, ErrorMessage))
 	{
 		return FMCPToolResult::Error(ErrorMessage);
 	}
@@ -66,9 +95,16 @@ FMCPToolResult FMCPTool_SetProperty::Execute(const TSharedRef<FJsonObject>& Para
 	TSharedPtr<FJsonObject> ResultData = MakeShared<FJsonObject>();
 	ResultData->SetStringField(TEXT("actor"), Actor->GetName());
 	ResultData->SetStringField(TEXT("property"), PropertyPath);
+	if (!ComponentName.IsEmpty())
+	{
+		ResultData->SetStringField(TEXT("component"), ComponentName);
+	}
 
 	return FMCPToolResult::Success(
-		FString::Printf(TEXT("Set property '%s' on actor '%s'"), *PropertyPath, *Actor->GetName()),
+		FString::Printf(TEXT("Set property '%s' on actor '%s'%s"),
+			*PropertyPath,
+			*Actor->GetName(),
+			ComponentName.IsEmpty() ? TEXT("") : *FString::Printf(TEXT(" (component: %s)"), *ComponentName)),
 		ResultData
 	);
 }
@@ -452,10 +488,57 @@ bool FMCPTool_SetProperty::SetPropertyFromJson(UObject* Object, const FString& P
 		return false;
 	}
 
-	// Parse property path into components for traversal
-	// Example: "StaticMeshComponent.RelativeLocation.X" -> ["StaticMeshComponent", "RelativeLocation", "X"]
+	// Parse property path into components for traversal.
+	// Canonical form: "StaticMeshComponent.RelativeLocation.X" or "AIPerception.SensesConfig[0].SightRadius".
+	// Legacy form (still accepted): "AIPerception.SensesConfig.0.SightRadius" with numeric segments.
+	//
+	// We normalize by tokenizing through the shared parser. If a segment carries an inline "[N]",
+	// we expand it into two synthetic segments (Name then stringified index) so the existing
+	// NavigateToProperty loop — which already handles a numeric segment after an array property —
+	// works unchanged. If the input used the legacy dot-numeric form, we emit a Verbose log to
+	// nudge migration without breaking existing scripts.
+	TArray<FString> RawSegments;
+	FString SplitErr;
+	if (!FPropertyPathParser::SplitPath(PropertyPath, RawSegments, SplitErr))
+	{
+		OutError = SplitErr;
+		return false;
+	}
+
 	TArray<FString> PathParts;
-	PropertyPath.ParseIntoArray(PathParts, TEXT("."), true);
+	PathParts.Reserve(RawSegments.Num() * 2);
+	bool bHasBracketForm = false;
+	bool bHasLegacyDotNumeric = false;
+	for (const FString& Raw : RawSegments)
+	{
+		if (Raw.IsNumeric())
+		{
+			bHasLegacyDotNumeric = true;
+			PathParts.Add(Raw);
+			continue;
+		}
+
+		FString SegName;
+		int32 SegIndex = INDEX_NONE;
+		FString ParseErr;
+		if (!FPropertyPathParser::ParseSegment(Raw, SegName, SegIndex, ParseErr))
+		{
+			OutError = ParseErr;
+			return false;
+		}
+		PathParts.Add(SegName);
+		if (SegIndex != INDEX_NONE)
+		{
+			bHasBracketForm = true;
+			PathParts.Add(FString::FromInt(SegIndex));
+		}
+	}
+
+	if (bHasLegacyDotNumeric && !bHasBracketForm)
+	{
+		// Per-call deprecation hint: prefer "Foo[N].Bar" over "Foo.N.Bar". Visible at default Log level.
+		UE_LOG(LogUnrealClaude, Log, TEXT("set_property: dot-numeric path '%s' is the legacy form; '[N]' bracket syntax is preferred."), *PropertyPath);
+	}
 
 	UObject* TargetObject = nullptr;
 	FProperty* Property = nullptr;

--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/Tools/MCPTool_SetProperty.h
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/Tools/MCPTool_SetProperty.h
@@ -18,21 +18,24 @@ public:
 		Info.Description = TEXT(
 			"Set any property value on an actor, including component properties.\n\n"
 			"This is a powerful tool for modifying actor settings that aren't covered by other tools. "
-			"Use dot notation to access nested properties and components.\n\n"
+			"Use dot notation to access nested properties and components, and '[N]' to index arrays.\n\n"
 			"Property path examples:\n"
 			"- 'bHidden' - Actor visibility\n"
 			"- 'Tags' - Actor tags array\n"
 			"- 'LightComponent.Intensity' - Light intensity\n"
 			"- 'LightComponent.LightColor' - Light color {R, G, B, A}\n"
 			"- 'StaticMeshComponent.RelativeScale3D' - Mesh scale\n"
-			"- 'RootComponent.RelativeLocation' - Root position\n\n"
+			"- 'RootComponent.RelativeLocation' - Root position\n"
+			"- 'AIPerception.SensesConfig[0].SightRadius' - first sense config's sight radius\n\n"
+			"The legacy 'Foo.0.Bar' dot-numeric form for array indices is still accepted but '[N]' is preferred (matches blueprint_query and blueprint_modify).\n\n"
 			"Value types: strings, numbers, booleans, objects (FVector, FRotator, FLinearColor), arrays.\n\n"
 			"Returns: Confirmation of property change."
 		);
 		Info.Parameters = {
 			FMCPToolParameter(TEXT("actor_name"), TEXT("string"), TEXT("The name of the actor to modify"), true),
-			FMCPToolParameter(TEXT("property"), TEXT("string"), TEXT("The property path to set (e.g., 'RelativeLocation', 'LightComponent.Intensity')"), true),
-			FMCPToolParameter(TEXT("value"), TEXT("any"), TEXT("The value to set (type depends on property)"), true)
+			FMCPToolParameter(TEXT("property"), TEXT("string"), TEXT("The property path to set. Dot navigates structs/objects; '[N]' indexes arrays. Examples: 'RelativeLocation', 'LightComponent.Intensity', 'AIPerception.SensesConfig[0].SightRadius'"), true),
+			FMCPToolParameter(TEXT("value"), TEXT("any"), TEXT("The value to set (type depends on property)"), true),
+			FMCPToolParameter(TEXT("component_name"), TEXT("string"), TEXT("Optional: re-root the write at this component on the actor (exact match) instead of the actor itself. Eliminates the in-path component lookup."), false)
 		};
 		Info.Annotations = FMCPToolAnnotations::Modifying();
 		return Info;

--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/PropertyPathParser.cpp
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/PropertyPathParser.cpp
@@ -41,13 +41,22 @@ bool FPropertyPathParser::ParseSegment(const FString& Raw, FString& OutName, int
 		return false;
 	}
 
-	OutName = Raw.Left(Open);
-	OutIndex = FCString::Atoi(*IndexStr);
-	if (OutIndex < 0)
+	// Use Atoi64 + explicit int32-range check so overlong digit strings can't wrap silently.
+	// (Validator caps bracket length to 9 digits; this is belt-and-braces for direct callers.)
+	const int64 Parsed = FCString::Atoi64(*IndexStr);
+	if (Parsed < 0)
 	{
 		OutErr = FString::Printf(TEXT("Negative index in '%s'"), *Raw);
 		return false;
 	}
+	if (Parsed > static_cast<int64>(TNumericLimits<int32>::Max()))
+	{
+		OutErr = FString::Printf(TEXT("Index in '%s' exceeds int32 range"), *Raw);
+		return false;
+	}
+
+	OutName = Raw.Left(Open);
+	OutIndex = static_cast<int32>(Parsed);
 	return true;
 }
 

--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/PropertyPathParser.cpp
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/PropertyPathParser.cpp
@@ -1,0 +1,86 @@
+// Copyright Natali Caggiano. All Rights Reserved.
+
+#include "PropertyPathParser.h"
+
+bool FPropertyPathParser::ParseSegment(const FString& Raw, FString& OutName, int32& OutIndex, FString& OutErr)
+{
+	OutIndex = INDEX_NONE;
+	OutName.Empty();
+	OutErr.Empty();
+
+	if (Raw.IsEmpty())
+	{
+		OutErr = TEXT("Empty path segment");
+		return false;
+	}
+
+	const int32 Open = Raw.Find(TEXT("["));
+	if (Open == INDEX_NONE)
+	{
+		OutName = Raw;
+		return true;
+	}
+
+	if (Open == 0)
+	{
+		OutErr = FString::Printf(TEXT("Malformed path segment '%s' (expected Name[N])"), *Raw);
+		return false;
+	}
+
+	const int32 Close = Raw.Find(TEXT("]"));
+	if (Close == INDEX_NONE || Close != Raw.Len() - 1 || Close <= Open + 1)
+	{
+		OutErr = FString::Printf(TEXT("Malformed path segment '%s' (expected Name[N])"), *Raw);
+		return false;
+	}
+
+	const FString IndexStr = Raw.Mid(Open + 1, Close - Open - 1);
+	if (!IndexStr.IsNumeric())
+	{
+		OutErr = FString::Printf(TEXT("Non-numeric index in '%s'"), *Raw);
+		return false;
+	}
+
+	OutName = Raw.Left(Open);
+	OutIndex = FCString::Atoi(*IndexStr);
+	if (OutIndex < 0)
+	{
+		OutErr = FString::Printf(TEXT("Negative index in '%s'"), *Raw);
+		return false;
+	}
+	return true;
+}
+
+bool FPropertyPathParser::SplitPath(const FString& Path, TArray<FString>& OutSegments, FString& OutErr)
+{
+	OutSegments.Reset();
+	OutErr.Empty();
+
+	if (Path.IsEmpty())
+	{
+		OutErr = TEXT("Empty property path");
+		return false;
+	}
+
+	if (Path.StartsWith(TEXT(".")) || Path.EndsWith(TEXT(".")))
+	{
+		OutErr = TEXT("Property path cannot start or end with a dot");
+		return false;
+	}
+
+	if (Path.Contains(TEXT("..")))
+	{
+		OutErr = TEXT("Property path cannot contain consecutive dots");
+		return false;
+	}
+
+	Path.ParseIntoArray(OutSegments, TEXT("."), true);
+
+	if (OutSegments.Num() == 0)
+	{
+		OutErr = TEXT("Empty property path");
+		return false;
+	}
+
+	return true;
+}

--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/PropertyPathParser.h
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/PropertyPathParser.h
@@ -1,0 +1,41 @@
+// Copyright Natali Caggiano. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+/**
+ * Shared parser for the canonical property-path syntax used by both read
+ * (FPropertySerializer::GetPropertyByPath) and write
+ * (FMCPTool_BlueprintModify::SetComponentPropertyFromJson, FMCPTool_SetProperty::NavigateToProperty)
+ * code paths.
+ *
+ * Canonical syntax:
+ *   - Dot separates segments:        "Foo.Bar.Baz"
+ *   - Brackets index arrays:         "Foo[3]"
+ *   - Combined for nested arrays:    "AIPerception.SensesConfig[0].SightRadius"
+ *
+ * Canonical error messages (kept consistent across read and write so LLMs can pattern-match):
+ *   - "Malformed path segment 'X' (expected Name[N])"
+ *   - "Non-numeric index in 'X'"
+ *   - "Negative index in 'X'"
+ *   - "Property path cannot contain consecutive dots"
+ *   - "Property path cannot start or end with a dot"
+ */
+class FPropertyPathParser
+{
+public:
+	/**
+	 * Parse a single segment like "Foo" or "Foo[3]".
+	 * On success: OutName="Foo", OutIndex=3 (or INDEX_NONE for unbracketed names).
+	 * On failure: OutErr is set to a canonical error message.
+	 */
+	static bool ParseSegment(const FString& Raw, FString& OutName, int32& OutIndex, FString& OutErr);
+
+	/**
+	 * Split a full path into segments on '.', validating overall shape (no leading/trailing dot,
+	 * no consecutive dots, no empty segments). Each returned segment may carry a "[N]" suffix and
+	 * must be passed through ParseSegment by the caller before lookup.
+	 */
+	static bool SplitPath(const FString& Path, TArray<FString>& OutSegments, FString& OutErr);
+};

--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/PropertySerializer.cpp
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/PropertySerializer.cpp
@@ -1,51 +1,11 @@
 // Copyright Natali Caggiano. All Rights Reserved.
 
 #include "PropertySerializer.h"
+#include "PropertyPathParser.h"
 #include "UnrealClaudeUtils.h"
 #include "UObject/UnrealType.h"
 #include "UObject/TextProperty.h"
 #include "UObject/EnumProperty.h"
-
-namespace
-{
-	/**
-	 * Parse a path segment like "Foo" or "Foo[3]" into a name + optional index.
-	 * Returns false on malformed input ("Foo[", "Foo[abc]", "Foo[]", "Foo[3]bar").
-	 */
-	bool ParsePathSegment(const FString& Raw, FString& OutName, int32& OutIndex, FString& OutErr)
-	{
-		OutIndex = INDEX_NONE;
-		const int32 Open = Raw.Find(TEXT("["));
-		if (Open == INDEX_NONE)
-		{
-			OutName = Raw;
-			return true;
-		}
-
-		const int32 Close = Raw.Find(TEXT("]"));
-		if (Close == INDEX_NONE || Close != Raw.Len() - 1 || Close <= Open + 1)
-		{
-			OutErr = FString::Printf(TEXT("Malformed path segment '%s' (expected Name[N])"), *Raw);
-			return false;
-		}
-
-		const FString IndexStr = Raw.Mid(Open + 1, Close - Open - 1);
-		if (!IndexStr.IsNumeric())
-		{
-			OutErr = FString::Printf(TEXT("Non-numeric index in '%s'"), *Raw);
-			return false;
-		}
-
-		OutName = Raw.Left(Open);
-		OutIndex = FCString::Atoi(*IndexStr);
-		if (OutIndex < 0)
-		{
-			OutErr = FString::Printf(TEXT("Negative index in '%s'"), *Raw);
-			return false;
-		}
-		return true;
-	}
-}
 
 TSharedPtr<FJsonValue> FPropertySerializer::PropertyToJsonValue(FProperty* Property, const void* ValuePtr)
 {
@@ -313,7 +273,7 @@ FPropertySerializer::FPropertyPathResult FPropertySerializer::GetPropertyByPath(
 		FString SegName;
 		int32 SegIndex = INDEX_NONE;
 		FString ParseErr;
-		if (!ParsePathSegment(PathParts[i], SegName, SegIndex, ParseErr))
+		if (!FPropertyPathParser::ParseSegment(PathParts[i], SegName, SegIndex, ParseErr))
 		{
 			Result.Error = ParseErr;
 			return Result;
@@ -402,7 +362,7 @@ FPropertySerializer::FPropertyPathResult FPropertySerializer::GetPropertyByPath(
 	FString LeafName;
 	int32 LeafIndex = INDEX_NONE;
 	FString LeafErr;
-	if (!ParsePathSegment(PathParts.Last(), LeafName, LeafIndex, LeafErr))
+	if (!FPropertyPathParser::ParseSegment(PathParts.Last(), LeafName, LeafIndex, LeafErr))
 	{
 		Result.Error = LeafErr;
 		return Result;

--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/PropertySerializer.cpp
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/PropertySerializer.cpp
@@ -6,7 +6,54 @@
 #include "UObject/TextProperty.h"
 #include "UObject/EnumProperty.h"
 
+namespace
+{
+	/**
+	 * Parse a path segment like "Foo" or "Foo[3]" into a name + optional index.
+	 * Returns false on malformed input ("Foo[", "Foo[abc]", "Foo[]", "Foo[3]bar").
+	 */
+	bool ParsePathSegment(const FString& Raw, FString& OutName, int32& OutIndex, FString& OutErr)
+	{
+		OutIndex = INDEX_NONE;
+		const int32 Open = Raw.Find(TEXT("["));
+		if (Open == INDEX_NONE)
+		{
+			OutName = Raw;
+			return true;
+		}
+
+		const int32 Close = Raw.Find(TEXT("]"));
+		if (Close == INDEX_NONE || Close != Raw.Len() - 1 || Close <= Open + 1)
+		{
+			OutErr = FString::Printf(TEXT("Malformed path segment '%s' (expected Name[N])"), *Raw);
+			return false;
+		}
+
+		const FString IndexStr = Raw.Mid(Open + 1, Close - Open - 1);
+		if (!IndexStr.IsNumeric())
+		{
+			OutErr = FString::Printf(TEXT("Non-numeric index in '%s'"), *Raw);
+			return false;
+		}
+
+		OutName = Raw.Left(Open);
+		OutIndex = FCString::Atoi(*IndexStr);
+		if (OutIndex < 0)
+		{
+			OutErr = FString::Printf(TEXT("Negative index in '%s'"), *Raw);
+			return false;
+		}
+		return true;
+	}
+}
+
 TSharedPtr<FJsonValue> FPropertySerializer::PropertyToJsonValue(FProperty* Property, const void* ValuePtr)
+{
+	FPropertyRecursionContext Ctx;
+	return PropertyToJsonValue(Property, ValuePtr, Ctx);
+}
+
+TSharedPtr<FJsonValue> FPropertySerializer::PropertyToJsonValue(FProperty* Property, const void* ValuePtr, FPropertyRecursionContext& Ctx)
 {
 	if (!Property || !ValuePtr)
 	{
@@ -71,7 +118,7 @@ TSharedPtr<FJsonValue> FPropertySerializer::PropertyToJsonValue(FProperty* Prope
 		FScriptArrayHelper ArrayHelper(ArrayProp, ValuePtr);
 		for (int32 i = 0; i < ArrayHelper.Num(); ++i)
 		{
-			JsonArray.Add(PropertyToJsonValue(ArrayProp->Inner, ArrayHelper.GetRawPtr(i)));
+			JsonArray.Add(PropertyToJsonValue(ArrayProp->Inner, ArrayHelper.GetRawPtr(i), Ctx));
 		}
 		return MakeShared<FJsonValueArray>(JsonArray);
 	}
@@ -89,7 +136,7 @@ TSharedPtr<FJsonValue> FPropertySerializer::PropertyToJsonValue(FProperty* Prope
 
 			FString KeyStr;
 			MapProp->KeyProp->ExportTextItem_Direct(KeyStr, MapHelper.GetKeyPtr(i), nullptr, nullptr, PPF_None);
-			TSharedPtr<FJsonValue> ValJson = PropertyToJsonValue(MapProp->ValueProp, MapHelper.GetValuePtr(i));
+			TSharedPtr<FJsonValue> ValJson = PropertyToJsonValue(MapProp->ValueProp, MapHelper.GetValuePtr(i), Ctx);
 			MapObj->SetField(KeyStr, ValJson);
 		}
 		return MakeShared<FJsonValueObject>(MapObj);
@@ -120,11 +167,48 @@ TSharedPtr<FJsonValue> FPropertySerializer::PropertyToJsonValue(FProperty* Prope
 	if (FObjectPropertyBase* ObjProp = CastField<FObjectPropertyBase>(Property))
 	{
 		UObject* Obj = ObjProp->GetObjectPropertyValue(ValuePtr);
-		if (Obj)
+		if (!Obj)
+		{
+			return MakeShared<FJsonValueString>(TEXT("None"));
+		}
+
+		const bool bInstanced = Property->HasAnyPropertyFlags(CPF_PersistentInstance | CPF_InstancedReference);
+		if (!bInstanced || !Ctx.CanRecurse())
 		{
 			return MakeShared<FJsonValueString>(Obj->GetPathName());
 		}
-		return MakeShared<FJsonValueString>(TEXT("None"));
+
+		if (Ctx.Visited.Contains(Obj))
+		{
+			return MakeShared<FJsonValueString>(FString::Printf(TEXT("(cycle: %s)"), *Obj->GetPathName()));
+		}
+		Ctx.Visited.Add(Obj);
+		Ctx.CurrentDepth++;
+
+		TSharedPtr<FJsonObject> NestedObj = MakeShared<FJsonObject>();
+		NestedObj->SetStringField(TEXT("_class"), Obj->GetClass()->GetName());
+		NestedObj->SetStringField(TEXT("_path"), Obj->GetPathName());
+
+		for (TFieldIterator<FProperty> It(Obj->GetClass()); It; ++It)
+		{
+			FProperty* InnerProp = *It;
+			if (!Ctx.bIncludeNonEdit && ShouldSkipProperty(InnerProp))
+			{
+				continue;
+			}
+			if (Ctx.IsBudgetExhausted())
+			{
+				NestedObj->SetBoolField(TEXT("_truncated"), true);
+				break;
+			}
+
+			const void* InnerValuePtr = InnerProp->ContainerPtrToValuePtr<void>(Obj);
+			NestedObj->SetField(InnerProp->GetName(), PropertyToJsonValue(InnerProp, InnerValuePtr, Ctx));
+			Ctx.PropertyCount++;
+		}
+
+		Ctx.CurrentDepth--;
+		return MakeShared<FJsonValueObject>(NestedObj);
 	}
 
 	FString ExportedText;
@@ -198,6 +282,12 @@ TSharedPtr<FJsonValue> FPropertySerializer::StructToJsonValue(FStructProperty* S
 
 FPropertySerializer::FPropertyPathResult FPropertySerializer::GetPropertyByPath(UObject* Object, const FString& PropertyPath)
 {
+	FPropertyRecursionContext Ctx;
+	return GetPropertyByPath(Object, PropertyPath, Ctx);
+}
+
+FPropertySerializer::FPropertyPathResult FPropertySerializer::GetPropertyByPath(UObject* Object, const FString& PropertyPath, FPropertyRecursionContext& Ctx)
+{
 	FPropertyPathResult Result;
 
 	if (!Object)
@@ -220,10 +310,66 @@ FPropertySerializer::FPropertyPathResult FPropertySerializer::GetPropertyByPath(
 
 	for (int32 i = 0; i < PathParts.Num() - 1; ++i)
 	{
-		FProperty* Prop = CurrentStruct->FindPropertyByName(FName(*PathParts[i]));
+		FString SegName;
+		int32 SegIndex = INDEX_NONE;
+		FString ParseErr;
+		if (!ParsePathSegment(PathParts[i], SegName, SegIndex, ParseErr))
+		{
+			Result.Error = ParseErr;
+			return Result;
+		}
+
+		FProperty* Prop = CurrentStruct->FindPropertyByName(FName(*SegName));
 		if (!Prop)
 		{
-			Result.Error = FString::Printf(TEXT("Property '%s' not found on %s"), *PathParts[i], *CurrentStruct->GetName());
+			Result.Error = FString::Printf(TEXT("Property '%s' not found on %s"), *SegName, *CurrentStruct->GetName());
+			return Result;
+		}
+
+		// If the segment carries an index, the property must be an array; advance into the indexed element.
+		if (SegIndex != INDEX_NONE)
+		{
+			FArrayProperty* ArrayProp = CastField<FArrayProperty>(Prop);
+			if (!ArrayProp)
+			{
+				Result.Error = FString::Printf(TEXT("Property '%s' has index [%d] but is not an array (type: %s)"),
+					*SegName, SegIndex, *Prop->GetCPPType());
+				return Result;
+			}
+
+			void* ArrayValuePtr = ArrayProp->ContainerPtrToValuePtr<void>(CurrentContainer);
+			FScriptArrayHelper ArrayHelper(ArrayProp, ArrayValuePtr);
+			if (SegIndex >= ArrayHelper.Num())
+			{
+				Result.Error = FString::Printf(TEXT("Index [%d] out of bounds for '%s' (size: %d)"),
+					SegIndex, *SegName, ArrayHelper.Num());
+				return Result;
+			}
+
+			void* ElemPtr = ArrayHelper.GetRawPtr(SegIndex);
+			FProperty* InnerProp = ArrayProp->Inner;
+
+			if (FStructProperty* StructInner = CastField<FStructProperty>(InnerProp))
+			{
+				CurrentContainer = ElemPtr;
+				CurrentStruct = StructInner->Struct;
+				continue;
+			}
+			if (FObjectProperty* ObjInner = CastField<FObjectProperty>(InnerProp))
+			{
+				UObject* NestedObj = ObjInner->GetObjectPropertyValue(ElemPtr);
+				if (!NestedObj)
+				{
+					Result.Error = FString::Printf(TEXT("Element '%s[%d]' is null"), *SegName, SegIndex);
+					return Result;
+				}
+				CurrentContainer = NestedObj;
+				CurrentStruct = NestedObj->GetClass();
+				continue;
+			}
+
+			Result.Error = FString::Printf(TEXT("Cannot navigate into '%s[%d]' (inner type: %s)"),
+				*SegName, SegIndex, *InnerProp->GetCPPType());
 			return Result;
 		}
 
@@ -239,7 +385,7 @@ FPropertySerializer::FPropertyPathResult FPropertySerializer::GetPropertyByPath(
 			UObject* NestedObj = ObjProp->GetObjectPropertyValue(ObjProp->ContainerPtrToValuePtr<void>(CurrentContainer));
 			if (!NestedObj)
 			{
-				Result.Error = FString::Printf(TEXT("Nested object '%s' is null"), *PathParts[i]);
+				Result.Error = FString::Printf(TEXT("Nested object '%s' is null"), *SegName);
 				return Result;
 			}
 			CurrentContainer = NestedObj;
@@ -247,11 +393,21 @@ FPropertySerializer::FPropertyPathResult FPropertySerializer::GetPropertyByPath(
 			continue;
 		}
 
-		Result.Error = FString::Printf(TEXT("Cannot navigate through '%s' (type: %s) — not a struct or object property"), *PathParts[i], *Prop->GetCPPType());
+		Result.Error = FString::Printf(TEXT("Cannot navigate through '%s' (type: %s) — not a struct or object property"),
+			*SegName, *Prop->GetCPPType());
 		return Result;
 	}
 
-	const FString& LeafName = PathParts.Last();
+	// Leaf segment.
+	FString LeafName;
+	int32 LeafIndex = INDEX_NONE;
+	FString LeafErr;
+	if (!ParsePathSegment(PathParts.Last(), LeafName, LeafIndex, LeafErr))
+	{
+		Result.Error = LeafErr;
+		return Result;
+	}
+
 	FProperty* LeafProp = CurrentStruct->FindPropertyByName(FName(*LeafName));
 	if (!LeafProp)
 	{
@@ -259,8 +415,33 @@ FPropertySerializer::FPropertyPathResult FPropertySerializer::GetPropertyByPath(
 		return Result;
 	}
 
+	if (LeafIndex != INDEX_NONE)
+	{
+		FArrayProperty* ArrayProp = CastField<FArrayProperty>(LeafProp);
+		if (!ArrayProp)
+		{
+			Result.Error = FString::Printf(TEXT("Leaf '%s' has index [%d] but is not an array (type: %s)"),
+				*LeafName, LeafIndex, *LeafProp->GetCPPType());
+			return Result;
+		}
+
+		void* ArrayValuePtr = ArrayProp->ContainerPtrToValuePtr<void>(CurrentContainer);
+		FScriptArrayHelper ArrayHelper(ArrayProp, ArrayValuePtr);
+		if (LeafIndex >= ArrayHelper.Num())
+		{
+			Result.Error = FString::Printf(TEXT("Leaf index [%d] out of bounds for '%s' (size: %d)"),
+				LeafIndex, *LeafName, ArrayHelper.Num());
+			return Result;
+		}
+
+		const void* ElemPtr = ArrayHelper.GetRawPtr(LeafIndex);
+		Result.Value = PropertyToJsonValue(ArrayProp->Inner, ElemPtr, Ctx);
+		Result.bSuccess = true;
+		return Result;
+	}
+
 	const void* LeafValuePtr = LeafProp->ContainerPtrToValuePtr<void>(CurrentContainer);
-	Result.Value = PropertyToJsonValue(LeafProp, LeafValuePtr);
+	Result.Value = PropertyToJsonValue(LeafProp, LeafValuePtr, Ctx);
 	Result.bSuccess = true;
 	return Result;
 }
@@ -286,6 +467,12 @@ bool FPropertySerializer::ShouldSkipProperty(FProperty* Property)
 }
 
 TSharedPtr<FJsonObject> FPropertySerializer::GetCDOOverrides(UObject* CDO, UObject* ParentCDO, bool bEditableOnly)
+{
+	FPropertyRecursionContext Ctx;
+	return GetCDOOverrides(CDO, ParentCDO, bEditableOnly, Ctx);
+}
+
+TSharedPtr<FJsonObject> FPropertySerializer::GetCDOOverrides(UObject* CDO, UObject* ParentCDO, bool bEditableOnly, FPropertyRecursionContext& Ctx)
 {
 	TSharedPtr<FJsonObject> Overrides = MakeShared<FJsonObject>();
 
@@ -322,8 +509,9 @@ TSharedPtr<FJsonObject> FPropertySerializer::GetCDOOverrides(UObject* CDO, UObje
 			}
 		}
 
-		TSharedPtr<FJsonValue> JsonVal = PropertyToJsonValue(Property, CDOValuePtr);
+		TSharedPtr<FJsonValue> JsonVal = PropertyToJsonValue(Property, CDOValuePtr, Ctx);
 		Overrides->SetField(Property->GetName(), JsonVal);
+		Ctx.PropertyCount++;
 	}
 
 	return Overrides;

--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/PropertySerializer.cpp
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/PropertySerializer.cpp
@@ -78,7 +78,13 @@ TSharedPtr<FJsonValue> FPropertySerializer::PropertyToJsonValue(FProperty* Prope
 		FScriptArrayHelper ArrayHelper(ArrayProp, ValuePtr);
 		for (int32 i = 0; i < ArrayHelper.Num(); ++i)
 		{
+			if (Ctx.IsBudgetExhausted())
+			{
+				JsonArray.Add(MakeShared<FJsonValueString>(TEXT("_truncated")));
+				break;
+			}
 			JsonArray.Add(PropertyToJsonValue(ArrayProp->Inner, ArrayHelper.GetRawPtr(i), Ctx));
+			Ctx.PropertyCount++;
 		}
 		return MakeShared<FJsonValueArray>(JsonArray);
 	}
@@ -93,11 +99,17 @@ TSharedPtr<FJsonValue> FPropertySerializer::PropertyToJsonValue(FProperty* Prope
 			{
 				continue;
 			}
+			if (Ctx.IsBudgetExhausted())
+			{
+				MapObj->SetBoolField(TEXT("_truncated"), true);
+				break;
+			}
 
 			FString KeyStr;
 			MapProp->KeyProp->ExportTextItem_Direct(KeyStr, MapHelper.GetKeyPtr(i), nullptr, nullptr, PPF_None);
 			TSharedPtr<FJsonValue> ValJson = PropertyToJsonValue(MapProp->ValueProp, MapHelper.GetValuePtr(i), Ctx);
 			MapObj->SetField(KeyStr, ValJson);
+			Ctx.PropertyCount++;
 		}
 		return MakeShared<FJsonValueObject>(MapObj);
 	}
@@ -138,6 +150,9 @@ TSharedPtr<FJsonValue> FPropertySerializer::PropertyToJsonValue(FProperty* Prope
 			return MakeShared<FJsonValueString>(Obj->GetPathName());
 		}
 
+		// Visited acts as a true cycle-detector: it tracks objects on the *current* recursion
+		// stack and is popped on return. This avoids false-positive "(cycle:)" labels for the
+		// common UE pattern of two properties pointing at the same shared subobject.
 		if (Ctx.Visited.Contains(Obj))
 		{
 			return MakeShared<FJsonValueString>(FString::Printf(TEXT("(cycle: %s)"), *Obj->GetPathName()));
@@ -168,6 +183,7 @@ TSharedPtr<FJsonValue> FPropertySerializer::PropertyToJsonValue(FProperty* Prope
 		}
 
 		Ctx.CurrentDepth--;
+		Ctx.Visited.Remove(Obj);
 		return MakeShared<FJsonValueObject>(NestedObj);
 	}
 
@@ -256,12 +272,13 @@ FPropertySerializer::FPropertyPathResult FPropertySerializer::GetPropertyByPath(
 		return Result;
 	}
 
+	// Route through the shared parser so read and write paths agree on shape validation
+	// (no leading/trailing/consecutive dots, no empty segments).
 	TArray<FString> PathParts;
-	PropertyPath.ParseIntoArray(PathParts, TEXT("."), true);
-
-	if (PathParts.Num() == 0)
+	FString SplitErr;
+	if (!FPropertyPathParser::SplitPath(PropertyPath, PathParts, SplitErr))
 	{
-		Result.Error = TEXT("Empty property path");
+		Result.Error = SplitErr;
 		return Result;
 	}
 

--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/PropertySerializer.h
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/PropertySerializer.h
@@ -5,10 +5,39 @@
 #include "CoreMinimal.h"
 #include "Dom/JsonValue.h"
 
+/**
+ * Walk state for optional recursion into instanced UObject subobjects.
+ * Default-constructed state (MaxDepth=0) means "no recursion" — preserves
+ * existing single-level behavior for callers that don't opt in.
+ */
+struct FPropertyRecursionContext
+{
+	/** Caps how many levels deep to recurse into instanced object fields. 0 disables recursion. */
+	int32 MaxDepth = 0;
+
+	/** Total property-count cap across the whole walk. Prevents runaway expansion on dense graphs. */
+	int32 MaxProperties = 500;
+
+	/** When true, ignore the editable/blueprint-visible filter and emit everything (still skips transient/deprecated/delegates). */
+	bool bIncludeNonEdit = false;
+
+	// --- Mutable walk state ---
+	int32 CurrentDepth = 0;
+	int32 PropertyCount = 0;
+	TSet<const UObject*> Visited;
+
+	bool IsBudgetExhausted() const { return PropertyCount >= MaxProperties; }
+	bool CanRecurse() const { return CurrentDepth < MaxDepth && !IsBudgetExhausted(); }
+};
+
 class FPropertySerializer
 {
 public:
+	/** Single-level serialization (legacy). Equivalent to a default-constructed recursion context. */
 	static TSharedPtr<FJsonValue> PropertyToJsonValue(FProperty* Property, const void* ValuePtr);
+
+	/** Context-aware serialization. Recurses into instanced object fields when Ctx allows. */
+	static TSharedPtr<FJsonValue> PropertyToJsonValue(FProperty* Property, const void* ValuePtr, FPropertyRecursionContext& Ctx);
 
 	struct FPropertyPathResult
 	{
@@ -17,9 +46,19 @@ public:
 		bool bSuccess = false;
 	};
 
+	/** Path-walk (legacy). Splits on '.' only; leaf serialization is single-level. */
 	static FPropertyPathResult GetPropertyByPath(UObject* Object, const FString& PropertyPath);
 
+	/**
+	 * Path-walk with recursion context and `[N]` array-index support.
+	 * Each path segment may be `Name` or `Name[N]`. Leaf serialization respects Ctx.
+	 */
+	static FPropertyPathResult GetPropertyByPath(UObject* Object, const FString& PropertyPath, FPropertyRecursionContext& Ctx);
+
 	static TSharedPtr<FJsonObject> GetCDOOverrides(UObject* CDO, UObject* ParentCDO, bool bEditableOnly = true);
+
+	/** CDO override dump with optional recursion. */
+	static TSharedPtr<FJsonObject> GetCDOOverrides(UObject* CDO, UObject* ParentCDO, bool bEditableOnly, FPropertyRecursionContext& Ctx);
 
 	static bool ShouldSkipProperty(FProperty* Property);
 

--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/Tests/MCPParamValidatorTests.cpp
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/Tests/MCPParamValidatorTests.cpp
@@ -231,6 +231,63 @@ bool FMCPParamValidator_ValidatePropertyPath_Format::RunTest(const FString& Para
 	return true;
 }
 
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FMCPParamValidator_ValidatePropertyPath_BracketIndices,
+	"UnrealClaude.MCP.ParamValidator.PropertyPath.BracketIndices",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter
+)
+
+bool FMCPParamValidator_ValidatePropertyPath_BracketIndices::RunTest(const FString& Parameters)
+{
+	FString Error;
+
+	// Valid bracket forms.
+	TestTrue("Single bracketed segment is valid",
+		FMCPParamValidator::ValidatePropertyPath(TEXT("Items[0]"), Error));
+	TestTrue("Bracket plus dot navigation is valid",
+		FMCPParamValidator::ValidatePropertyPath(TEXT("Foo[0].Bar"), Error));
+	TestTrue("Multi-digit index is valid",
+		FMCPParamValidator::ValidatePropertyPath(TEXT("Foo[123].Bar"), Error));
+	TestTrue("Multiple bracketed segments in one path is valid",
+		FMCPParamValidator::ValidatePropertyPath(TEXT("A[0].B[1].C"), Error));
+	TestTrue("AIPerception SensesConfig path is valid",
+		FMCPParamValidator::ValidatePropertyPath(TEXT("SensesConfig[0].SightRadius"), Error));
+
+	// Invalid bracket forms.
+	TestFalse("Empty brackets are invalid",
+		FMCPParamValidator::ValidatePropertyPath(TEXT("Foo[]"), Error));
+	TestFalse("Non-numeric bracket body is invalid",
+		FMCPParamValidator::ValidatePropertyPath(TEXT("Foo[abc]"), Error));
+	TestFalse("Mixed-content bracket body is invalid",
+		FMCPParamValidator::ValidatePropertyPath(TEXT("Foo[1a]"), Error));
+	TestFalse("Unclosed bracket is invalid",
+		FMCPParamValidator::ValidatePropertyPath(TEXT("Foo[0"), Error));
+	TestFalse("Stray close bracket is invalid",
+		FMCPParamValidator::ValidatePropertyPath(TEXT("Foo0]"), Error));
+	TestFalse("Nested brackets are invalid",
+		FMCPParamValidator::ValidatePropertyPath(TEXT("Foo[0[1]]"), Error));
+	TestFalse("Negative index char (minus) is invalid",
+		FMCPParamValidator::ValidatePropertyPath(TEXT("Foo[-1]"), Error));
+	TestFalse("Overlong index (overflow defense) is invalid",
+		FMCPParamValidator::ValidatePropertyPath(TEXT("Foo[1234567890]"), Error));
+
+	// Backwards-compat: pre-bracket valid paths still validate.
+	TestTrue("Plain property still valid",
+		FMCPParamValidator::ValidatePropertyPath(TEXT("MyProperty"), Error));
+	TestTrue("Dot-numeric (legacy array form) still passes char check",
+		FMCPParamValidator::ValidatePropertyPath(TEXT("Foo.0.Bar"), Error));
+
+	// Regression guard: previously-rejected dangerous chars must still be rejected.
+	TestFalse("Angle brackets still rejected",
+		FMCPParamValidator::ValidatePropertyPath(TEXT("Property<T>"), Error));
+	TestFalse("Slash still rejected",
+		FMCPParamValidator::ValidatePropertyPath(TEXT("Foo/Bar"), Error));
+	TestFalse("Semicolon still rejected",
+		FMCPParamValidator::ValidatePropertyPath(TEXT("Foo;Bar"), Error));
+
+	return true;
+}
+
 // ===== Numeric Value Validation Tests =====
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(

--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/Tests/PropertyPathParserTests.cpp
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/Tests/PropertyPathParserTests.cpp
@@ -1,0 +1,165 @@
+// Copyright Natali Caggiano. All Rights Reserved.
+
+/**
+ * Unit tests for FPropertyPathParser — the canonical "Foo[N].Bar" path syntax used by
+ * blueprint_query get_defaults, blueprint_modify set_cdo_default / set_component_default,
+ * and set_property.
+ */
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "PropertyPathParser.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+// ===== ParseSegment =====
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FPropertyPathParser_ParseSegment_Plain,
+	"UnrealClaude.PropertyPathParser.ParseSegment.Plain",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter
+)
+
+bool FPropertyPathParser_ParseSegment_Plain::RunTest(const FString& Parameters)
+{
+	FString Name; int32 Index = 99; FString Err;
+
+	TestTrue("Plain name parses", FPropertyPathParser::ParseSegment(TEXT("Foo"), Name, Index, Err));
+	TestEqual("Plain name preserved", Name, TEXT("Foo"));
+	TestEqual("Plain name has no index", Index, (int32)INDEX_NONE);
+	TestTrue("Plain name has no error", Err.IsEmpty());
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FPropertyPathParser_ParseSegment_Indexed,
+	"UnrealClaude.PropertyPathParser.ParseSegment.Indexed",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter
+)
+
+bool FPropertyPathParser_ParseSegment_Indexed::RunTest(const FString& Parameters)
+{
+	FString Name; int32 Index; FString Err;
+
+	TestTrue("Indexed segment parses", FPropertyPathParser::ParseSegment(TEXT("Foo[3]"), Name, Index, Err));
+	TestEqual("Name extracted", Name, TEXT("Foo"));
+	TestEqual("Index extracted", Index, 3);
+
+	TestTrue("Multi-digit index parses", FPropertyPathParser::ParseSegment(TEXT("Bar[123]"), Name, Index, Err));
+	TestEqual("Multi-digit name", Name, TEXT("Bar"));
+	TestEqual("Multi-digit value", Index, 123);
+
+	TestTrue("Zero index parses", FPropertyPathParser::ParseSegment(TEXT("Items[0]"), Name, Index, Err));
+	TestEqual("Zero index value", Index, 0);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FPropertyPathParser_ParseSegment_Malformed,
+	"UnrealClaude.PropertyPathParser.ParseSegment.Malformed",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter
+)
+
+bool FPropertyPathParser_ParseSegment_Malformed::RunTest(const FString& Parameters)
+{
+	FString Name; int32 Index; FString Err;
+
+	TestFalse("Unclosed bracket rejected",       FPropertyPathParser::ParseSegment(TEXT("Foo["),       Name, Index, Err));
+	TestFalse("Empty brackets rejected",         FPropertyPathParser::ParseSegment(TEXT("Foo[]"),      Name, Index, Err));
+	TestFalse("Non-numeric index rejected",      FPropertyPathParser::ParseSegment(TEXT("Foo[abc]"),   Name, Index, Err));
+	TestFalse("Trailing chars after ] rejected", FPropertyPathParser::ParseSegment(TEXT("Foo[3]bar"),  Name, Index, Err));
+	TestFalse("Bracket without name rejected",   FPropertyPathParser::ParseSegment(TEXT("[3]"),        Name, Index, Err));
+	TestFalse("Empty segment rejected",          FPropertyPathParser::ParseSegment(TEXT(""),           Name, Index, Err));
+
+	return true;
+}
+
+// ===== SplitPath =====
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FPropertyPathParser_SplitPath_Mixed,
+	"UnrealClaude.PropertyPathParser.SplitPath.Mixed",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter
+)
+
+bool FPropertyPathParser_SplitPath_Mixed::RunTest(const FString& Parameters)
+{
+	TArray<FString> Segments; FString Err;
+
+	TestTrue("Mixed path splits", FPropertyPathParser::SplitPath(TEXT("AIPerception.SensesConfig[0].SightRadius"), Segments, Err));
+	if (Segments.Num() == 3)
+	{
+		TestEqual("Segment 0", Segments[0], TEXT("AIPerception"));
+		TestEqual("Segment 1", Segments[1], TEXT("SensesConfig[0]"));
+		TestEqual("Segment 2", Segments[2], TEXT("SightRadius"));
+
+		// Each segment must round-trip through ParseSegment.
+		FString Name; int32 Index; FString PErr;
+		TestTrue("Seg0 round-trips",  FPropertyPathParser::ParseSegment(Segments[0], Name, Index, PErr));
+		TestEqual("Seg0 name", Name, TEXT("AIPerception"));
+		TestEqual("Seg0 has no index", Index, (int32)INDEX_NONE);
+
+		TestTrue("Seg1 round-trips",  FPropertyPathParser::ParseSegment(Segments[1], Name, Index, PErr));
+		TestEqual("Seg1 name", Name, TEXT("SensesConfig"));
+		TestEqual("Seg1 index", Index, 0);
+
+		TestTrue("Seg2 round-trips",  FPropertyPathParser::ParseSegment(Segments[2], Name, Index, PErr));
+		TestEqual("Seg2 name", Name, TEXT("SightRadius"));
+		TestEqual("Seg2 has no index", Index, (int32)INDEX_NONE);
+	}
+	else
+	{
+		AddError(FString::Printf(TEXT("Expected 3 segments, got %d"), Segments.Num()));
+	}
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FPropertyPathParser_SplitPath_RejectsEmpty,
+	"UnrealClaude.PropertyPathParser.SplitPath.RejectsEmpty",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter
+)
+
+bool FPropertyPathParser_SplitPath_RejectsEmpty::RunTest(const FString& Parameters)
+{
+	TArray<FString> Segments; FString Err;
+
+	TestFalse("Empty path rejected",        FPropertyPathParser::SplitPath(TEXT(""),         Segments, Err));
+	TestFalse("Leading dot rejected",       FPropertyPathParser::SplitPath(TEXT(".Foo"),     Segments, Err));
+	TestFalse("Trailing dot rejected",      FPropertyPathParser::SplitPath(TEXT("Foo."),     Segments, Err));
+	TestFalse("Consecutive dots rejected",  FPropertyPathParser::SplitPath(TEXT("Foo..Bar"), Segments, Err));
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FPropertyPathParser_SplitPath_SingleSegment,
+	"UnrealClaude.PropertyPathParser.SplitPath.SingleSegment",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter
+)
+
+bool FPropertyPathParser_SplitPath_SingleSegment::RunTest(const FString& Parameters)
+{
+	TArray<FString> Segments; FString Err;
+
+	TestTrue("Single name path splits", FPropertyPathParser::SplitPath(TEXT("MaxWalkSpeed"), Segments, Err));
+	TestEqual("Single segment count", Segments.Num(), 1);
+	if (Segments.Num() >= 1)
+	{
+		TestEqual("Single segment value", Segments[0], TEXT("MaxWalkSpeed"));
+	}
+
+	TestTrue("Single bracketed segment splits", FPropertyPathParser::SplitPath(TEXT("Items[0]"), Segments, Err));
+	TestEqual("Single bracket segment count", Segments.Num(), 1);
+	if (Segments.Num() >= 1)
+	{
+		TestEqual("Single bracket segment value", Segments[0], TEXT("Items[0]"));
+	}
+
+	return true;
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS


### PR DESCRIPTION
 ## Motivation

  A common LLM-driven workflow against AI Blueprints requires reading and writing deeply nested instanced UObject defaults — e.g. AI Controller's
  `AIPerception → SensesConfig[0] → SightRadius`. None of the existing tools could do this:

  - `get_defaults` stops at the first instanced object boundary; arrays of `UObject*` collapse to arrays of path strings.
  - `get_defaults` / `set_cdo_default` can't reach SCS component templates (the `AIPerception` field on a controller's CDO is null because the SCS
  owns the editor-time template).
  - No tool supports `[N]` array indexing in property paths.

  ## What this PR adds

  **Read side (`blueprint_query` `get_defaults`):**
  - `max_depth` — recurse into instanced UObject fields (default 0, max 8)
  - `max_properties` — total property-count cap during recursion (default 500, max 5000)
  - `include_non_edit` — bypass the editable-only filter
  - `component_name` — re-root the read at an SCS / CDO component template
  - `[N]` array indexing in property path strings

  **Write side (`blueprint_modify` `set_cdo_default`):**
  - `component_name` — re-root the write at an SCS / CDO component template
  - `[N]` array indexing in property path strings (both navigation and leaf)

  **Actor-level `set_property`:**
  - `component_name` — explicit component re-rooting (skips fuzzy in-path lookup)
  - `[N]` indexing accepted alongside the legacy `Foo.0.Bar` form (legacy form still works, emits a `Log`-level deprecation hint)

  A new shared `FPropertyPathParser` is the single source of truth for path syntax across all three tools, so read and write agree byte-for-byte on
  tokenization and shape validation.

  ## Backward compatibility

  Every existing call shape on every modified tool returns byte-identical output without any new params. Existing
  `FPropertySerializer::PropertyToJsonValue` / `GetPropertyByPath` / `GetCDOOverrides` 2/3-arg signatures are kept as wrappers that pass a default
  (zero-depth) recursion context, so all five existing callers (`ComponentInspector`, `AnimGraphEditor`, `GameFrameworkEditor`, `get_defaults`,
  `GetCDOOverrides` itself) compile and behave identically.

  ## Verification

  End-to-end against UE 5.7 in-editor on `/AscentCombatFramework/Blueprints/AI/Controllers/ACFAIControllerBP`:

  - Read `SensesConfig[0].SightRadius` via `get_defaults` (`component_name=AIPerception`, `max_depth=2`): returns `2000` ✓
  - Write `SensesConfig[0].SightRadius=2750` via `set_cdo_default` (`component_name=AIPerception`): success, `compile_status=UpToDate`,
  `root=AIPerception`, `root_class=AIPerceptionComponent` ✓
  - Read-back: returns `2750` ✓
  - Revert to `2000`: success ✓ (project state unchanged by verification)
  - Backwards-compat smoke (`set_cdo_default property=bAllowStrafe` — no new params): identical legacy result shape ✓
  - UBT `BuildPlugin`: 0 errors, 0 new warnings (one pre-existing `WidgetEditor.cpp` `UMovieScene::GetBindings` deprecation, unrelated to this PR)

  ## Tests

  - **New** `PropertyPathParserTests.cpp` — `ParseSegment` plain/indexed/malformed/overflow cases + `SplitPath` shape validation cases.
  - **Extended** `MCPParamValidatorTests.cpp` — adds `FMCPParamValidator_ValidatePropertyPath_BracketIndices` covering valid bracket forms, malformed
  brackets (`[]`, `[abc]`, `[1a]`, unclosed, stray close, nested), negative-index char rejection, overlong-index overflow defense, and regression
  guards for previously-rejected dangerous chars (`<`, `>`, `;`, `/`).

  ## Out of scope (deferred to follow-up)

  - `FPropertySerializer::StructToJsonValue` is not recursion-context-aware. Instanced UObject fields inside structs still emit as path strings even
  at `MaxDepth>0`. Consistent and safe but a documented ceiling.
  - The legacy `Foo.0.Bar` syntax in `set_property` is kept as a silent alias; the deprecation hint logs at `Log` level. A future PR can flip to
  `Warning` or remove the alias entirely once telemetry shows no usage.

  ## Notes for the maintainer

  - The 3 commits split cleanly along the natural seams (read side, write side, pre-PR review fixes) so the review-finding diff is visible separately.
   Happy to squash on merge if preferred.
  - The shared `FPropertyPathParser` was extracted in commit 2 from an anonymous-namespace helper in `PropertySerializer.cpp`; subsequent callers
  (`set_cdo_default`, `set_property`) route through it, so any path-syntax change has one place to update.
  - `set_component_default` becomes functionally equivalent to `set_cdo_default + component_name` after this PR. Kept for backward compat per
  maintainer preference; tool description nudges new callers toward `set_cdo_default`.

  ## Commits

  1. `feat(blueprint_query): recursive get_defaults for instanced subobjects` — read-side recursion + SCS templates + `[N]` indexing.
  2. `feat(blueprint_modify, set_property): write-side parity for nested instanced subobjects` — write-side parity + shared `FPropertyPathParser`.
  3. `fix(blueprint_query, blueprint_modify): address pre-PR review findings` — index-overflow defense, read/write resolution-order alignment,
  recursion-budget enforcement on arrays/maps, cycle-set pop on return, validator on write paths.