### PR TITLE
fix: UE 5.8 compatibility — FSharedString JSON keys, RigVM include path, retarget API

### DIFF
--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/AnimationBlueprintUtils.cpp
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/AnimationBlueprintUtils.cpp
@@ -941,7 +941,7 @@ TSharedPtr<FJsonObject> FAnimationBlueprintUtils::ExecuteBatchOperations(
 				{
 					for (const auto& Pair : (*BindingsObj)->Values)
 					{
-						Bindings.Add(Pair.Key, Pair.Value->AsString());
+						Bindings.Add(FString(Pair.Key), Pair.Value->AsString());
 					}
 				}
 				bOpSuccess = SetStateBlendSpace(

--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/ControlRigEditor.cpp
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/ControlRigEditor.cpp
@@ -12,7 +12,11 @@
 #include "RigVMModel/RigVMPin.h"
 #include "RigVMModel/RigVMLink.h"
 #include "RigVMModel/RigVMController.h"
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 8
+#include "RigVMCore/RigVMVariableDescription.h"
+#else
 #include "RigVMModel/RigVMVariableDescription.h"
+#endif
 #include "Rigs/RigHierarchy.h"
 
 // ============================================================================

--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/GameFrameworkEditor.cpp
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/GameFrameworkEditor.cpp
@@ -621,7 +621,7 @@ TSharedPtr<FJsonObject> FGameFrameworkEditor::SetRow(const FString& TablePath, c
 			}
 			return ErrorResult(FString::Printf(TEXT("Failed to set '%s': %s"), *Pair.Key, *FieldError));
 		}
-		UpdatedFields.Add(Pair.Key);
+		UpdatedFields.Add(FString(Pair.Key));
 	}
 
 	if (bIsNewRow)

--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/MCPToolBase.cpp
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/MCPToolBase.cpp
@@ -363,7 +363,7 @@ bool FMCPToolBase::SetMapPropertyFromJson(
 		uint8* PairKeyPtr = MapHelper.GetKeyPtr(Index);
 		uint8* PairValuePtr = MapHelper.GetValuePtr(Index);
 
-		TSharedPtr<FJsonValue> KeyJsonValue = MakeShared<FJsonValueString>(Pair.Key);
+		TSharedPtr<FJsonValue> KeyJsonValue = MakeShared<FJsonValueString>(FString(Pair.Key));
 		FString KeyContext = FString::Printf(TEXT("%s[key='%s']"), *PropertyPath, *Pair.Key);
 		if (!SetSinglePropertyFromJson(KeyProp, PairKeyPtr, KeyJsonValue, KeyContext, OutError))
 		{

--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/MCPToolRegistry.cpp
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/MCPToolRegistry.cpp
@@ -317,9 +317,9 @@ FMCPToolResult FMCPToolRegistry::ExecuteTool(const FString& ToolName, const TSha
 		TArray<FString> UnknownParams;
 		for (const auto& KV : Params->Values)
 		{
-			if (!DeclaredParams.Contains(KV.Key))
+			if (!DeclaredParams.Contains(FString(KV.Key)))
 			{
-				UnknownParams.Add(KV.Key);
+				UnknownParams.Add(FString(KV.Key));
 			}
 		}
 

--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/Tools/MCPTool_AnimBlueprintModify.cpp
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/Tools/MCPTool_AnimBlueprintModify.cpp
@@ -824,7 +824,7 @@ FMCPToolResult FMCPTool_AnimBlueprintModify::HandleSetStateAnimation(const FStri
 		{
 			for (const auto& Pair : (*BindingsObj)->Values)
 			{
-				Bindings.Add(Pair.Key, Pair.Value->AsString());
+				Bindings.Add(FString(Pair.Key), Pair.Value->AsString());
 			}
 		}
 		bSuccess = FAnimationBlueprintUtils::SetStateBlendSpace(

--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/Tools/MCPTool_BlueprintModify.cpp
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/Tools/MCPTool_BlueprintModify.cpp
@@ -584,7 +584,7 @@ FMCPToolResult FMCPTool_BlueprintModify::ExecuteAddNode(const TSharedRef<FJsonOb
 				if (PinValue.Value->TryGetString(PinValueStr))
 				{
 					FString PinError;
-					FBlueprintUtils::SetPinDefaultValue(Graph, NodeId, PinValue.Key, PinValueStr, PinError);
+					FBlueprintUtils::SetPinDefaultValue(Graph, NodeId, FString(PinValue.Key), PinValueStr, PinError);
 				}
 			}
 		}
@@ -739,7 +739,7 @@ bool FMCPTool_BlueprintModify::CreateNodesFromSpec(
 				if (PinValue.Value->TryGetString(PinValueStr))
 				{
 					FString PinError;
-					FBlueprintUtils::SetPinDefaultValue(Graph, NodeId, PinValue.Key, PinValueStr, PinError);
+					FBlueprintUtils::SetPinDefaultValue(Graph, NodeId, FString(PinValue.Key), PinValueStr, PinError);
 				}
 			}
 		}
@@ -1817,7 +1817,7 @@ bool FMCPTool_BlueprintModify::SetStructValue(FStructProperty* StructProp, void*
 		for (const auto& Pair : (*ObjVal)->Values)
 		{
 			if (!bFirst) TextRepresentation += TEXT(",");
-			TextRepresentation += Pair.Key.ToUpper() + TEXT("=");
+			TextRepresentation += FString(Pair.Key).ToUpper() + TEXT("=");
 
 			double NumVal;
 			FString StrVal;
@@ -1903,14 +1903,14 @@ FMCPToolResult FMCPTool_BlueprintModify::ExecuteAddDebugPrint(const TSharedRef<F
 					FString ParamVal;
 					if (Pair.Value->TryGetString(ParamVal))
 					{
-						FuncItem.Params.Add(Pair.Key, ParamVal);
+						FuncItem.Params.Add(FString(Pair.Key), ParamVal);
 					}
 					else
 					{
 						double NumVal;
 						if (Pair.Value->TryGetNumber(NumVal))
 						{
-							FuncItem.Params.Add(Pair.Key, FString::FromInt((int32)NumVal));
+							FuncItem.Params.Add(FString(Pair.Key), FString::FromInt((int32)NumVal));
 						}
 					}
 				}

--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/Tools/MCPTool_GameplayDebug.cpp
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/Tools/MCPTool_GameplayDebug.cpp
@@ -670,7 +670,7 @@ FMCPToolResult FMCPTool_GameplayDebug::ExecuteRunSequence(const TSharedRef<FJson
 			auto ApplyFileDefault = [&](const FString& Key) {
 				if (!Params->HasField(Key) && FileRoot->HasField(Key))
 				{
-					Params->SetField(Key, FileRoot->Values.FindRef(Key));
+					Params->SetField(Key, FileRoot->TryGetField(Key));
 				}
 			};
 			ApplyFileDefault(TEXT("name"));

--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/Tools/MCPTool_Material.cpp
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/Tools/MCPTool_Material.cpp
@@ -585,7 +585,7 @@ bool FMCPTool_Material::ApplyParametersFromJson(UMaterialInstanceConstant* MatIn
 			if (Pair.Value->TryGetNumber(Value))
 			{
 				FString Error;
-				if (!SetScalarParameter(MatInst, Pair.Key, static_cast<float>(Value), Error))
+				if (!SetScalarParameter(MatInst, FString(Pair.Key), static_cast<float>(Value), Error))
 				{
 					Errors.Add(Error);
 					bAllSuccess = false;
@@ -611,7 +611,7 @@ bool FMCPTool_Material::ApplyParametersFromJson(UMaterialInstanceConstant* MatIn
 				(*ColorObj)->TryGetNumberField(TEXT("a"), Color.A);
 
 				FString Error;
-				if (!SetVectorParameter(MatInst, Pair.Key, Color, Error))
+				if (!SetVectorParameter(MatInst, FString(Pair.Key), Color, Error))
 				{
 					Errors.Add(Error);
 					bAllSuccess = false;
@@ -630,7 +630,7 @@ bool FMCPTool_Material::ApplyParametersFromJson(UMaterialInstanceConstant* MatIn
 			if (Pair.Value->TryGetString(TexturePath))
 			{
 				FString Error;
-				if (!SetTextureParameter(MatInst, Pair.Key, TexturePath, Error))
+				if (!SetTextureParameter(MatInst, FString(Pair.Key), TexturePath, Error))
 				{
 					Errors.Add(Error);
 					bAllSuccess = false;

--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/Tools/MCPTool_SetProperty.cpp
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MCP/Tools/MCPTool_SetProperty.cpp
@@ -392,7 +392,7 @@ bool FMCPTool_SetProperty::SetStructPropertyValue(FStructProperty* StructProp, v
 		for (const auto& Pair : (*ObjVal)->Values)
 		{
 			if (!bFirst) TextRepresentation += TEXT(",");
-			TextRepresentation += Pair.Key.ToUpper() + TEXT("=");
+			TextRepresentation += FString(Pair.Key).ToUpper() + TEXT("=");
 
 			double NumVal;
 			FString StrVal;

--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MontageEditor.cpp
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/MontageEditor.cpp
@@ -777,7 +777,7 @@ bool FMontageEditor::SetPropertiesOnObject(UObject* Object,
 
 	for (const auto& Pair : Properties->Values)
 	{
-		const FString& Key = Pair.Key;
+		const FString Key(Pair.Key);
 		const TSharedPtr<FJsonValue>& Value = Pair.Value;
 
 		if (Key == TEXT("_class"))

--- a/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/RetargetEditor.cpp
+++ b/Plugin/UELLMToolkit/Source/UELLMToolkit/Private/RetargetEditor.cpp
@@ -1470,7 +1470,25 @@ TSharedPtr<FJsonObject> FRetargetEditor::BatchRetarget(const FString& Retargeter
 	}
 
 	// Run DuplicateAndRetarget
-#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 7
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 8
+	// 5.8 added TargetPath/bUseSourcePath params and deprecated this API in favor of RunBatchRetarget
+	PRAGMA_DISABLE_DEPRECATION_WARNINGS
+	TArray<FAssetData> NewAssets = UIKRetargetBatchOperation::DuplicateAndRetarget(
+		AssetsToRetarget,
+		SourceMesh,
+		TargetMesh,
+		Retargeter,
+		TEXT(""),       // Search
+		TEXT(""),       // Replace
+		Prefix,         // Prefix
+		TEXT(""),       // Suffix
+		TEXT(""),       // TargetPath
+		false,          // bUseSourcePath
+		false,          // bIncludeReferencedAssets
+		true            // bOverwriteExistingFiles
+	);
+	PRAGMA_ENABLE_DEPRECATION_WARNINGS
+#elif ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION == 7
 	TArray<FAssetData> NewAssets = UIKRetargetBatchOperation::DuplicateAndRetarget(
 		AssetsToRetarget,
 		SourceMesh,


### PR DESCRIPTION
## Summary

Unreal Engine 5.8 introduces three breaking changes that prevent the plugin from compiling. This PR fixes all of them while keeping 5.6/5.7 builds working (every change is either a no-op on older engines or version-gated).

### 1. `FJsonObject::Values` keys are no longer `FString` (11 files)

UE 5.8 changed the key type of `FJsonObject::Values` from `FString` to `UE::FSharedString`, which has no implicit conversion to `FString`. Every place that passed `Pair.Key` to something expecting an `FString` fails to compile.

Fix: wrap those keys in an explicit `FString(...)` construction. On 5.6/5.7 this is just a copy of an `FString`, so behavior is unchanged across versions. One call site (`MCPTool_GameplayDebug.cpp`) used `Values.FindRef(Key)` with an `FString` key, which no longer resolves — replaced with `TryGetField(Key)`, which accepts `FString`/`FStringView` on all supported versions.

Deref uses (`*Pair.Key`), `SetField`/`HasField` calls, and `== TEXT("...")` comparisons still compile via `FSharedString`'s own API and are left untouched.

### 2. `RigVMVariableDescription.h` moved (ControlRigEditor.cpp)

The header moved from `RigVMModel/` (RigVMDeveloper module) to `RigVMCore/` (RigVM module) in 5.8. The include is now version-gated.

### 3. `UIKRetargetBatchOperation::DuplicateAndRetarget` signature changed (RetargetEditor.cpp)

5.8 inserts `TargetPath` and `bUseSourcePath` parameters before `bIncludeReferencedAssets`, and deprecates the function in favor of `RunBatchRetarget`. Added a `>= 8` branch with the new signature (wrapped in deprecation-warning pragmas, following the existing 5.6/5.7 gate pattern in this file). Migrating to `RunBatchRetarget` is left as a follow-up since it requires restructuring the call site.

## Notes

- `UELLMToolkit.uplugin` still declares `"EngineVersion": "5.6.0"`, so 5.8 users get a one-time "designed for build 5.6.0, attempt to load anyway?" prompt. Left as-is since bumping it trades the prompt onto older versions — maintainer's call.
- UBT also warns that the plugin uses `InterchangePipelines` and `SkeletalMeshModifiers` without listing `Interchange` / `MeshModelingToolset` as plugin dependencies — pre-existing, not touched here.

## Testing

Compiled clean with UE 5.8.0 (Win64, Development Editor, MSVC 14.44) and loaded in the editor; the module starts and tools register normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
